### PR TITLE
Support MariaDB and obsolete MySQL

### DIFF
--- a/guile-dbd-mysql/configure.ac
+++ b/guile-dbd-mysql/configure.ac
@@ -40,7 +40,7 @@ AC_PROG_LIBTOOL
 AC_CHECK_TOOL([AR], [ar], :)
 AC_CHECK_TOOL([NM], [nm], :)
 AC_PATH_PROG([GUILECONFIG], [guile-config], :)
-AC_PATH_PROG([MYSQLCONFIG], [mysql_config], :)
+AC_PATH_PROG([MYSQLCONFIG], [mariadb_config], :)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CANONICAL_HOST
@@ -54,14 +54,14 @@ AC_FUNC_MALLOC
 AC_HEADER_STDC 
 
 # Checks for libs
-AC_CHECK_LIB(mysqlclient,mysql_init,,
+AC_CHECK_LIB(mariadbclient,mysql_init,,
         AC_MSG_ERROR([*** Can't find libmysql]))
 
 CFLAGS=`guile-config compile`
 LIBS=`guile-config link`
 
-MYSQL_CFLAGS=`mysql_config --cflags`
-MYSQL_LIBS=`mysql_config --libs_r`
+MYSQL_CFLAGS=`mariadb_config --cflags`
+MYSQL_LIBS=`mariadb_config --libs_r`
 
 CFLAGS="${CFLAGS} ${MYSQL_CFLAGS}"
 LIBS="${LIBS} ${MYSQL_LIBS}"

--- a/guile-dbd-mysql/src/guile-dbd-mysql.c
+++ b/guile-dbd-mysql/src/guile-dbd-mysql.c
@@ -23,8 +23,8 @@
 
 #include <guile-dbi/guile-dbi.h>
 #include <libguile.h>
-#include <mysql/mysql.h>
-#include <mysql/errmsg.h>
+#include <mariadb/mysql.h>
+#include <mariadb/errmsg.h>
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>


### PR DESCRIPTION
In the latest Debian (buster), there's no MySQL. I think using MariaDB is the trend. This patch fix this issue.