### PR TITLE
Fix broken links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ so, for now, things seem OK.
 Documentation
 -------------
 The guile-dbi user-manual and reference is
-[here](http://htmlpreview.github.com/?https://github.com/opencog/guile-dbi/blob/master/website/guile-dbi.html).
+[here](https://htmlpreview.github.io/?https://github.com/opencog/guile-dbi/blob/master/website/guile-dbi.html).
 
 A copy of the old, defunct website is
-[here](http://htmlpreview.github.com/?https://github.com/opencog/guile-dbi/blob/master/website/index.html).
+[here](https://htmlpreview.github.io/?https://github.com/opencog/guile-dbi/blob/master/website/index.html).
 
 Mailing List
 ------------
@@ -75,7 +75,7 @@ sudo make install
 ```
 
 After doing this, the tutorial in
-[the user manual](http://htmlpreview.github.com/?https://github.com/opencog/guile-dbi/blob/master/website/guile-dbi.html)
+[the user manual](https://htmlpreview.github.io/?https://github.com/opencog/guile-dbi/blob/master/website/guile-dbi.html)
 should work fine.
 
 

--- a/guile-dbi/README
+++ b/guile-dbi/README
@@ -59,7 +59,7 @@ and Linas Vepstas <linasvepstas@gmail.org>
    The doc directory contains the reference manual  and some examples.
 
    The www pages are at http://www.gnu.org/software/guile-dbi or
-   http://htmlpreview.github.com/?https://github.com/opencog/guile-dbi/blob/master/website/index.html
+   https://htmlpreview.github.io/?https://github.com/opencog/guile-dbi/blob/master/website/index.html
 
    The project page is at: https://github.com/opencog/guile-dbi
 


### PR DESCRIPTION
Hi,

The URL for the document was a broken link and I fixed it.


SEE: https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/