### PR TITLE
Add dbi-affected-rows

### DIFF
--- a/guile-dbd-mysql/src/guile-dbd-mysql.c
+++ b/guile-dbd-mysql/src/guile-dbd-mysql.c
@@ -67,7 +67,6 @@ typedef struct
   unsigned int num_fields;
 
   int retn;
-  int affected_rows;
 } gdbi_mysql_ds_t;
 
 static void free_binds (MYSQL_BIND *binds, int cnt)
@@ -76,10 +75,10 @@ static void free_binds (MYSQL_BIND *binds, int cnt)
     return;
 
   for (int i = 0; i < cnt; i++)
-  {
-    if (binds[i].buffer)
-      free (binds[i].buffer);
-  }
+    {
+      if (binds[i].buffer)
+        free (binds[i].buffer);
+    }
 
   free (binds);
 }
@@ -92,12 +91,12 @@ void __mysql_make_g_db_handle (gdbi_db_handle_t *dbh)
   SCM cp_list = SCM_EOL;
 
   if (scm_equal_p (scm_string_p (dbh->constr), SCM_BOOL_F) == SCM_BOOL_T)
-  {
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (
-      scm_from_int (1), scm_from_locale_string ("missing connection string"));
-    return;
-  }
+    {
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (
+                              scm_from_int (1), scm_from_locale_string ("missing connection string"));
+      return;
+    }
 
   cp_list = scm_string_split (dbh->constr, SCM_MAKE_CHAR (sep));
 
@@ -105,97 +104,97 @@ void __mysql_make_g_db_handle (gdbi_db_handle_t *dbh)
 
   items = scm_to_int (scm_length (cp_list));
   if (items >= 5 && items < 8)
-  {
-    void *ret = 0;
-    int port = 0;
-    char *user = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (0)));
-    char *pass = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (1)));
-    char *db = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (2)));
-    char *ctyp = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (3)));
-    char *loc = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (4)));
+    {
+      void *ret = 0;
+      int port = 0;
+      char *user = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (0)));
+      char *pass = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (1)));
+      char *db = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (2)));
+      char *ctyp = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (3)));
+      char *loc = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (4)));
 
-    mysqlP = (gdbi_mysql_ds_t *)calloc (sizeof (gdbi_mysql_ds_t), 1);
+      mysqlP = (gdbi_mysql_ds_t *)calloc (sizeof (gdbi_mysql_ds_t), 1);
 
-    if (mysqlP == NULL)
-    {
-      dbh->status = scm_cons (scm_from_int (errno), scm_from_locale_string (strerror (errno)));
-      return;
-    }
+      if (mysqlP == NULL)
+        {
+          dbh->status = scm_cons (scm_from_int (errno), scm_from_locale_string (strerror (errno)));
+          return;
+        }
 
-    mysqlP->mysql = mysql_init (NULL);
-    mysqlP->res = NULL;
+      mysqlP->mysql = mysql_init (NULL);
+      mysqlP->res = NULL;
 
-    if (strcmp (ctyp, "tcp") == 0)
-    {
-      char *sport = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
-      port = atoi (sport);
-      free (sport);
-      ret = mysql_real_connect (mysqlP->mysql, loc, user, pass, db, port, NULL, 0);
-      if (items == 7)
-      {
-        char *sretn = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (6)));
-        mysqlP->retn = atoi (sretn);
-        free (sretn);
-      }
-    }
-    else
-    {
-      ret = mysql_real_connect (mysqlP->mysql, NULL, user, pass, db, port, loc, 0);
-      if (items == 6)
-      {
-        char *sretn = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
-        mysqlP->retn = atoi (sretn);
-        free (sretn);
-      }
-    }
+      if (strcmp (ctyp, "tcp") == 0)
+        {
+          char *sport = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
+          port = atoi (sport);
+          free (sport);
+          ret = mysql_real_connect (mysqlP->mysql, loc, user, pass, db, port, NULL, 0);
+          if (items == 7)
+            {
+              char *sretn = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (6)));
+              mysqlP->retn = atoi (sretn);
+              free (sretn);
+            }
+        }
+      else
+        {
+          ret = mysql_real_connect (mysqlP->mysql, NULL, user, pass, db, port, loc, 0);
+          if (items == 6)
+            {
+              char *sretn = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
+              mysqlP->retn = atoi (sretn);
+              free (sretn);
+            }
+        }
 
-    /* free resources */
-    if (user)
-    {
-      free (user);
-    }
-    if (pass)
-    {
-      free (pass);
-    }
-    if (db)
-    {
-      free (db);
-    }
-    if (ctyp)
-    {
-      free (ctyp);
-    }
-    if (loc)
-    {
-      free (loc);
-    }
+      /* free resources */
+      if (user)
+        {
+          free (user);
+        }
+      if (pass)
+        {
+          free (pass);
+        }
+      if (db)
+        {
+          free (db);
+        }
+      if (ctyp)
+        {
+          free (ctyp);
+        }
+      if (loc)
+        {
+          free (loc);
+        }
 
-    if (ret == 0)
+      if (ret == 0)
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string (mysql_error (mysqlP->mysql)));
+          mysql_close (mysqlP->mysql);
+          mysqlP->mysql = NULL;
+          free (mysqlP);
+          dbh->db_info = NULL;
+          return;
+        }
+      else
+        {
+          /* todo: error msg to be translated */
+          dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("db connected"));
+          dbh->db_info = mysqlP;
+          dbh->closed = SCM_BOOL_F;
+          return;
+        }
+    }
+  else
     {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string (mysql_error (mysqlP->mysql)));
-      mysql_close (mysqlP->mysql);
-      mysqlP->mysql = NULL;
-      free (mysqlP);
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("invalid connection string"));
       dbh->db_info = NULL;
       return;
     }
-    else
-    {
-      /* todo: error msg to be translated */
-      dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("db connected"));
-      dbh->db_info = mysqlP;
-      dbh->closed = SCM_BOOL_F;
-      return;
-    }
-  }
-  else
-  {
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("invalid connection string"));
-    dbh->db_info = NULL;
-    return;
-  }
 
   return;
 }
@@ -204,67 +203,67 @@ void __mysql_close_g_db_handle (gdbi_db_handle_t *dbh)
 {
   gdbi_mysql_ds_t *mysqlP = (gdbi_mysql_ds_t *)dbh->db_info;
   if (mysqlP == NULL)
-  {
-    if (dbh->in_free)
-      return; /* don't scm anything if in GC */
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_locale_string ("dbd info not found"));
-    return;
-  }
-  else if (mysqlP->mysql == NULL)
-  {
-    if (0 == dbh->in_free)
     {
+      if (dbh->in_free)
+        return; /* don't scm anything if in GC */
       /* todo: error msg to be translated */
-      dbh->status
-        = scm_cons (scm_from_int (1),
-                    scm_from_locale_string ("dbi connection already closed"));
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_locale_string ("dbd info not found"));
+      return;
     }
-    free (dbh->db_info);
-    dbh->db_info = NULL;
-    return;
-  }
+  else if (mysqlP->mysql == NULL)
+    {
+      if (0 == dbh->in_free)
+        {
+          /* todo: error msg to be translated */
+          dbh->status
+            = scm_cons (scm_from_int (1),
+                        scm_from_locale_string ("dbi connection already closed"));
+        }
+      free (dbh->db_info);
+      dbh->db_info = NULL;
+      return;
+    }
 
   /* clean up prepared statement resources */
   if (mysqlP->result_bind)
-  {
-    free_binds (mysqlP->result_bind, mysqlP->num_fields);
-    mysqlP->result_bind = NULL;
-  }
+    {
+      free_binds (mysqlP->result_bind, mysqlP->num_fields);
+      mysqlP->result_bind = NULL;
+    }
 
   if (mysqlP->is_null)
-  {
-    free (mysqlP->is_null);
-    mysqlP->is_null = NULL;
-  }
+    {
+      free (mysqlP->is_null);
+      mysqlP->is_null = NULL;
+    }
 
   if (mysqlP->lengths)
-  {
-    free (mysqlP->lengths);
-    mysqlP->lengths = NULL;
-  }
+    {
+      free (mysqlP->lengths);
+      mysqlP->lengths = NULL;
+    }
 
   if (mysqlP->meta)
-  {
-    mysql_free_result (mysqlP->meta);
-    mysqlP->meta = NULL;
-  }
+    {
+      mysql_free_result (mysqlP->meta);
+      mysqlP->meta = NULL;
+    }
 
   if (mysqlP->stmt)
-  {
-    mysql_stmt_free_result (mysqlP->stmt);
-    mysql_stmt_close (mysqlP->stmt);
-    mysqlP->stmt = NULL;
-  }
+    {
+      mysql_stmt_free_result (mysqlP->stmt);
+      mysql_stmt_close (mysqlP->stmt);
+      mysqlP->stmt = NULL;
+    }
 
   mysql_close (mysqlP->mysql);
 
   if (mysqlP->res)
-  {
-    mysql_free_result (mysqlP->res);
-    mysqlP->res = NULL;
-  }
+    {
+      mysql_free_result (mysqlP->res);
+      mysqlP->res = NULL;
+    }
 
   free (dbh->db_info);
   dbh->db_info = NULL;
@@ -284,42 +283,42 @@ void __mysql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
   int err, i;
 
   if (dbh->db_info == NULL)
-  {
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("invalid dbi connection"));
-    return;
-  }
+    {
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("invalid dbi connection"));
+      return;
+    }
 
   mysqlP = (gdbi_mysql_ds_t *)dbh->db_info;
 
   if (mysqlP->res)
-  {
-    mysql_free_result (mysqlP->res);
-    mysqlP->res = NULL;
-  }
+    {
+      mysql_free_result (mysqlP->res);
+      mysqlP->res = NULL;
+    }
 
   err = mysql_real_query (mysqlP->mysql, query, strlen (query));
   for (i = 0; i < mysqlP->retn && err != 0; i++)
-  {
-    mysql_ping (mysqlP->mysql);
-    err = mysql_real_query (mysqlP->mysql, query, strlen (query));
-  }
+    {
+      mysql_ping (mysqlP->mysql);
+      err = mysql_real_query (mysqlP->mysql, query, strlen (query));
+    }
 
   if (err)
-  {
-    dbh->status
-      = scm_cons (scm_from_int (mysqlP->mysql->net.last_errno), scm_from_locale_string (mysql_error (mysqlP->mysql)));
-    return;
-  }
+    {
+      dbh->status
+        = scm_cons (scm_from_int (mysqlP->mysql->net.last_errno), scm_from_locale_string (mysql_error (mysqlP->mysql)));
+      return;
+    }
 
-  mysqlP->affected_rows = mysql_affected_rows (mysqlP->mysql);
+  dbh->affected_rows = mysql_affected_rows (mysqlP->mysql);
 
   mysqlP->res = mysql_use_result (mysqlP->mysql);
   if (mysqlP->res == NULL)
-  {
-    dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("query ok, no results"));
-    return;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("query ok, no results"));
+      return;
+    }
 
   dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("query ok, got results"));
 
@@ -338,74 +337,74 @@ SCM static getrow_for_stmt (gdbi_db_handle_t *dbh)
   status = mysql_stmt_fetch (mysqlP->stmt);
 
   if (0 != status)
-  {
-    /* todo: error msg to be translated */
-    if (MYSQL_NO_DATA == status)
     {
-      dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("row end"));
+      /* todo: error msg to be translated */
+      if (MYSQL_NO_DATA == status)
+        {
+          dbh->status = scm_cons (scm_from_int (0), scm_from_locale_string ("row end"));
+        }
+      else if (MYSQL_DATA_TRUNCATED == status)
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("data truncated"));
+        }
+      else
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("fetch failed"));
+        }
+      return (SCM_BOOL_F);
     }
-    else if (MYSQL_DATA_TRUNCATED == status)
-    {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("data truncated"));
-    }
-    else
-    {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("fetch failed"));
-    }
-    return (SCM_BOOL_F);
-  }
 
   for (f = 0; f < mysqlP->num_fields; f++)
-  {
-    MYSQL_BIND *b = &mysqlP->result_bind[f];
-    SCM value;
-
-    /* 1. SQL NULL */
-    if (mysqlP->is_null[f])
     {
-      value = SCM_UNSPECIFIED;
-    }
-    else
-    {
-      switch (b->buffer_type)
-      {
-      case MYSQL_TYPE_TINY:
-        value = scm_from_int ((int)(*(int8_t *)b->buffer));
-        break;
-      case MYSQL_TYPE_SHORT:
-        value = scm_from_int ((int)(*(int16_t *)b->buffer));
-        break;
-      case MYSQL_TYPE_LONG:
-      case MYSQL_TYPE_INT24:
-        value = scm_from_int (*(int32_t *)b->buffer);
-        break;
-      case MYSQL_TYPE_LONGLONG:
-        value = scm_from_int64 (*(long long *)b->buffer);
-        break;
-      case MYSQL_TYPE_DOUBLE:
-        value = scm_from_double (*(double *)b->buffer);
-        break;
-      case MYSQL_TYPE_FLOAT:
-        value = scm_from_double ((double)(*(float *)b->buffer));
-        break;
-      case MYSQL_TYPE_STRING:
-      case MYSQL_TYPE_VAR_STRING:
-      case MYSQL_TYPE_VARCHAR:
-        /* treat DECIMAL as string to avoid precision loss. */
-      case MYSQL_TYPE_NEWDECIMAL:
-        value = scm_from_locale_stringn ((char *)b->buffer, *b->length);
-        break;
-      default:
-        value = SCM_UNSPECIFIED;
-        break;
-      }
-    }
+      MYSQL_BIND *b = &mysqlP->result_bind[f];
+      SCM value;
 
-    /* 3. (column-name . value) */
-    retrow = scm_append (scm_list_2 (
-      retrow,
-      scm_list_1 (scm_cons (scm_from_locale_string (fields[f].name), value))));
-  }
+      /* 1. SQL NULL */
+      if (mysqlP->is_null[f])
+        {
+          value = SCM_UNSPECIFIED;
+        }
+      else
+        {
+          switch (b->buffer_type)
+            {
+            case MYSQL_TYPE_TINY:
+              value = scm_from_int ((int)(*(int8_t *)b->buffer));
+              break;
+            case MYSQL_TYPE_SHORT:
+              value = scm_from_int ((int)(*(int16_t *)b->buffer));
+              break;
+            case MYSQL_TYPE_LONG:
+            case MYSQL_TYPE_INT24:
+              value = scm_from_int (*(int32_t *)b->buffer);
+              break;
+            case MYSQL_TYPE_LONGLONG:
+              value = scm_from_int64 (*(long long *)b->buffer);
+              break;
+            case MYSQL_TYPE_DOUBLE:
+              value = scm_from_double (*(double *)b->buffer);
+              break;
+            case MYSQL_TYPE_FLOAT:
+              value = scm_from_double ((double)(*(float *)b->buffer));
+              break;
+            case MYSQL_TYPE_STRING:
+            case MYSQL_TYPE_VAR_STRING:
+            case MYSQL_TYPE_VARCHAR:
+              /* treat DECIMAL as string to avoid precision loss. */
+            case MYSQL_TYPE_NEWDECIMAL:
+              value = scm_from_locale_stringn ((char *)b->buffer, *b->length);
+              break;
+            default:
+              value = SCM_UNSPECIFIED;
+              break;
+            }
+        }
+
+      /* 3. (column-name . value) */
+      retrow = scm_append (scm_list_2 (
+                                       retrow,
+                                       scm_list_1 (scm_cons (scm_from_locale_string (fields[f].name), value))));
+    }
 
   dbh->status
     = scm_cons (scm_from_int (0), scm_from_locale_string ("row fetched"));
@@ -426,88 +425,88 @@ SCM getrow_common (gdbi_db_handle_t *dbh)
   mysqlP = (gdbi_mysql_ds_t *)dbh->db_info;
 
   if (NULL == mysqlP->res)
-  {
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_locale_string ("missing query result"));
-    return (SCM_BOOL_F);
-  }
+    {
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_locale_string ("missing query result"));
+      return (SCM_BOOL_F);
+    }
 
   if ((row = mysql_fetch_row (mysqlP->res)) == NULL)
-  {
-    /* todo: error msg to be translated */
-    dbh->status
-      = scm_cons (scm_from_int (0), scm_from_locale_string ("row end"));
-    return (SCM_BOOL_F);
-  }
+    {
+      /* todo: error msg to be translated */
+      dbh->status
+        = scm_cons (scm_from_int (0), scm_from_locale_string ("row end"));
+      return (SCM_BOOL_F);
+    }
 
   fnum = mysql_num_fields (mysqlP->res);
   fields = mysql_fetch_fields (mysqlP->res);
   les = mysql_fetch_lengths (mysqlP->res);
   for (f = 0; f < fnum; f++)
-  {
-
-    SCM value;
-    char *value_str = NULL;
-
-    switch (fields[f].type)
     {
-    case FIELD_TYPE_NULL:
-      value = SCM_BOOL_F;
-      break;
-    case FIELD_TYPE_TINY:
-    case FIELD_TYPE_SHORT:
-    case FIELD_TYPE_INT24:
-    case FIELD_TYPE_LONG:
-    case FIELD_TYPE_DECIMAL:
-      value_str = strndup (row[f], les[f]);
-      value = scm_from_long (atoi (value_str));
-      break;
-    case FIELD_TYPE_LONGLONG:
-      value_str = strndup (row[f], les[f]);
-      value = scm_from_long_long (atoll (value_str));
-      break;
-    case FIELD_TYPE_FLOAT:
-    case FIELD_TYPE_DOUBLE:
-    case FIELD_TYPE_NEWDECIMAL:
-      value_str = strndup (row[f], les[f]);
-      value = scm_from_double (atof (value_str));
-      break;
-    case FIELD_TYPE_STRING:
-    case FIELD_TYPE_ENUM:
-    case FIELD_TYPE_VAR_STRING:
-    case FIELD_TYPE_SET:
-    case FIELD_TYPE_BLOB:
-    case FIELD_TYPE_DATE:
-    case FIELD_TYPE_TIME:
-    case FIELD_TYPE_YEAR:
-      value_str = strndup (row[f], les[f]);
-      value = scm_from_locale_string (value_str);
-      break;
-    case FIELD_TYPE_DATETIME:
-    case FIELD_TYPE_TIMESTAMP:
-      /* (car (mktime (car (strptime "%Y-%m-%d %H:%M:%S" "2013-03-20
-         23:05:44")))) scm_mktime needs to use the default time zone because
-         MySQL stores times in UTC.  */
-      value_str = strndup (row[f], les[f]);
-      value = scm_from_locale_string (value_str);
-      value = scm_strptime (scm_from_locale_string ("%Y-%m-%d %H:%M:%S"), value);
-      value = SCM_CAR (value);
-      value = scm_mktime (value, scm_from_locale_string ("GMT+0"));
-      value = SCM_CAR (value);
-      break;
-    default:
-      /* todo: error msg to be translated */
-      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("unknown field type"));
-      return SCM_BOOL_F;
-      break;
+
+      SCM value;
+      char *value_str = NULL;
+
+      switch (fields[f].type)
+        {
+        case FIELD_TYPE_NULL:
+          value = SCM_BOOL_F;
+          break;
+        case FIELD_TYPE_TINY:
+        case FIELD_TYPE_SHORT:
+        case FIELD_TYPE_INT24:
+        case FIELD_TYPE_LONG:
+        case FIELD_TYPE_DECIMAL:
+          value_str = strndup (row[f], les[f]);
+          value = scm_from_long (atoi (value_str));
+          break;
+        case FIELD_TYPE_LONGLONG:
+          value_str = strndup (row[f], les[f]);
+          value = scm_from_long_long (atoll (value_str));
+          break;
+        case FIELD_TYPE_FLOAT:
+        case FIELD_TYPE_DOUBLE:
+        case FIELD_TYPE_NEWDECIMAL:
+          value_str = strndup (row[f], les[f]);
+          value = scm_from_double (atof (value_str));
+          break;
+        case FIELD_TYPE_STRING:
+        case FIELD_TYPE_ENUM:
+        case FIELD_TYPE_VAR_STRING:
+        case FIELD_TYPE_SET:
+        case FIELD_TYPE_BLOB:
+        case FIELD_TYPE_DATE:
+        case FIELD_TYPE_TIME:
+        case FIELD_TYPE_YEAR:
+          value_str = strndup (row[f], les[f]);
+          value = scm_from_locale_string (value_str);
+          break;
+        case FIELD_TYPE_DATETIME:
+        case FIELD_TYPE_TIMESTAMP:
+          /* (car (mktime (car (strptime "%Y-%m-%d %H:%M:%S" "2013-03-20
+             23:05:44")))) scm_mktime needs to use the default time zone because
+             MySQL stores times in UTC.  */
+          value_str = strndup (row[f], les[f]);
+          value = scm_from_locale_string (value_str);
+          value = scm_strptime (scm_from_locale_string ("%Y-%m-%d %H:%M:%S"), value);
+          value = SCM_CAR (value);
+          value = scm_mktime (value, scm_from_locale_string ("GMT+0"));
+          value = SCM_CAR (value);
+          break;
+        default:
+          /* todo: error msg to be translated */
+          dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string ("unknown field type"));
+          return SCM_BOOL_F;
+          break;
+        }
+      retrow = scm_append (scm_list_2 (retrow, scm_list_1 (scm_cons (scm_from_locale_string (fields[f].name), value))));
+      if (value_str != NULL)
+        {
+          free (value_str);
+        }
     }
-    retrow = scm_append (scm_list_2 (retrow, scm_list_1 (scm_cons (scm_from_locale_string (fields[f].name), value))));
-    if (value_str != NULL)
-    {
-      free (value_str);
-    }
-  }
   /* todo: error msg to be translated */
   dbh->status
     = scm_cons (scm_from_int (0), scm_from_locale_string ("row fetched"));
@@ -519,11 +518,11 @@ SCM __mysql_getrow_g_db_handle (gdbi_db_handle_t *dbh)
   gdbi_mysql_ds_t *mysqlP = (gdbi_mysql_ds_t *)dbh->db_info;
 
   if (mysqlP == NULL)
-  {
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_locale_string ("invalid dbi connection"));
-    return SCM_BOOL_F;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_locale_string ("invalid dbi connection"));
+      return SCM_BOOL_F;
+    }
 
   if (mysqlP->stmt)
     return getrow_for_stmt (dbh);
@@ -539,77 +538,77 @@ void __mysql_params_query_g_db_handle (gdbi_db_handle_t *dbh, const char *query,
   int i = 0;
 
   if (MAX_TMPVAR < argc)
-  {
-    char buf[100] = {0};
-    snprintf (buf, sizeof (buf), "Exceeds %d limit, too many parameters",
-              MAX_TMPVAR);
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (buf));
-    return;
-  }
+    {
+      char buf[100] = {0};
+      snprintf (buf, sizeof (buf), "Exceeds %d limit, too many parameters",
+                MAX_TMPVAR);
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (buf));
+      return;
+    }
 
   /* cleanup old state */
   if (mysqlP->res)
-  {
-    mysql_free_result (mysqlP->res);
-    mysqlP->res = NULL;
-  }
+    {
+      mysql_free_result (mysqlP->res);
+      mysqlP->res = NULL;
+    }
 
   if (mysqlP->meta)
-  {
-    mysql_free_result (mysqlP->meta);
-    mysqlP->meta = NULL;
-  }
+    {
+      mysql_free_result (mysqlP->meta);
+      mysqlP->meta = NULL;
+    }
 
   if (mysqlP->stmt)
-  {
-    mysql_stmt_close (mysqlP->stmt);
-    mysqlP->stmt = NULL;
-  }
+    {
+      mysql_stmt_close (mysqlP->stmt);
+      mysqlP->stmt = NULL;
+    }
 
   if (mysqlP->result_bind)
-  {
-    free_binds (mysqlP->result_bind, mysqlP->num_fields);
-    mysqlP->result_bind = NULL;
-  }
+    {
+      free_binds (mysqlP->result_bind, mysqlP->num_fields);
+      mysqlP->result_bind = NULL;
+    }
 
   if (mysqlP->is_null)
-  {
-    free (mysqlP->is_null);
-    mysqlP->is_null = NULL;
-  }
+    {
+      free (mysqlP->is_null);
+      mysqlP->is_null = NULL;
+    }
 
   if (mysqlP->lengths)
-  {
-    free (mysqlP->lengths);
-    mysqlP->lengths = NULL;
-  }
+    {
+      free (mysqlP->lengths);
+      mysqlP->lengths = NULL;
+    }
 
   mysqlP->stmt = mysql_stmt_init (mysqlP->mysql);
   if (NULL == mysqlP->stmt)
-  {
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("mysql stmt init failed"));
-    return;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("mysql stmt init failed"));
+      return;
+    }
 
   if (mysql_stmt_prepare (mysqlP->stmt, query, strlen (query)) != 0)
-  {
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (mysql_stmt_error (mysqlP->stmt)));
-    goto cleanup_stmt;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (mysql_stmt_error (mysqlP->stmt)));
+      goto cleanup_stmt;
+    }
 
   if ((int)mysql_stmt_param_count (mysqlP->stmt) != argc)
-  {
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("params count mismatch"));
-    goto cleanup_stmt;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("params count mismatch"));
+      goto cleanup_stmt;
+    }
 
   /* -------- bind params -------- */
   MYSQL_BIND *params_bind = calloc (argc, sizeof (MYSQL_BIND));
   if (!params_bind)
-  {
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("out of memory for params_bind"));
-    goto cleanup_stmt;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("out of memory for params_bind"));
+      goto cleanup_stmt;
+    }
 
   /* temp array to avoid malloc */
   long long nums[MAX_TMPVAR] = {0};
@@ -617,171 +616,171 @@ void __mysql_params_query_g_db_handle (gdbi_db_handle_t *dbh, const char *query,
   char *str[MAX_TMPVAR] = {0};
 
   for (i = 0; i < argc; i++)
-  {
-    if (scm_is_integer (argv[i]) || scm_is_bool (argv[i]))
     {
-      nums[i] = scm_is_bool (argv[i]) ? (scm_is_true (argv[i]) ? 1 : 0) : scm_to_long_long (argv[i]);
-      params_bind[i].buffer_type = MYSQL_TYPE_LONGLONG;
-      params_bind[i].buffer = &nums[i];
+      if (scm_is_integer (argv[i]) || scm_is_bool (argv[i]))
+        {
+          nums[i] = scm_is_bool (argv[i]) ? (scm_is_true (argv[i]) ? 1 : 0) : scm_to_long_long (argv[i]);
+          params_bind[i].buffer_type = MYSQL_TYPE_LONGLONG;
+          params_bind[i].buffer = &nums[i];
+        }
+      else if (scm_is_string (argv[i]))
+        {
+          char *s = scm_to_locale_string (argv[i]);
+          if (NULL == s)
+            {
+              dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("out of memory for string param"));
+              goto cleanup_params;
+            }
+          str[i] = s; /* save for later free */
+          params_bind[i].buffer_type = MYSQL_TYPE_STRING;
+          params_bind[i].buffer = s;
+          params_bind[i].buffer_length = strlen (s);
+        }
+      else if (scm_is_null (argv[i]))
+        {
+          params_bind[i].buffer_type = MYSQL_TYPE_NULL;
+        }
+      else
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("unsupported parameter type"));
+          goto cleanup_params;
+        }
     }
-    else if (scm_is_string (argv[i]))
-    {
-      char *s = scm_to_locale_string (argv[i]);
-      if (NULL == s)
-      {
-        dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("out of memory for string param"));
-        goto cleanup_params;
-      }
-      str[i] = s; /* save for later free */
-      params_bind[i].buffer_type = MYSQL_TYPE_STRING;
-      params_bind[i].buffer = s;
-      params_bind[i].buffer_length = strlen (s);
-    }
-    else if (scm_is_null (argv[i]))
-    {
-      params_bind[i].buffer_type = MYSQL_TYPE_NULL;
-    }
-    else
-    {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("unsupported parameter type"));
-      goto cleanup_params;
-    }
-  }
 
   if (mysql_stmt_bind_param (mysqlP->stmt, params_bind) != 0)
-  {
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (mysql_stmt_error (mysqlP->stmt)));
-    goto cleanup_params;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (mysql_stmt_error (mysqlP->stmt)));
+      goto cleanup_params;
+    }
 
   if (mysql_stmt_execute (mysqlP->stmt) != 0)
-  {
-    dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (mysql_stmt_error (mysqlP->stmt)));
-    goto cleanup_params;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (mysql_stmt_error (mysqlP->stmt)));
+      goto cleanup_params;
+    }
 
-  mysqlP->affected_rows = mysql_stmt_affected_rows (mysqlP->stmt);
+  dbh->affected_rows = mysql_stmt_affected_rows (mysqlP->stmt);
 
   /* -------- prepare result fetching -------- */
 
   mysqlP->num_fields = mysql_stmt_field_count (mysqlP->stmt);
 
   if (mysqlP->num_fields > 0)
-  {
-    mysqlP->result_bind = calloc (mysqlP->num_fields, sizeof (MYSQL_BIND));
-    mysqlP->lengths = calloc (mysqlP->num_fields, sizeof (unsigned long));
-    mysqlP->is_null = calloc (mysqlP->num_fields, sizeof (my_bool));
-
-    if (NULL == mysqlP->result_bind || NULL == mysqlP->lengths || NULL == mysqlP->is_null)
     {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result_bind start: out of memory"));
-      free_binds (mysqlP->result_bind, 0);
-      goto cleanup_stmt;
+      mysqlP->result_bind = calloc (mysqlP->num_fields, sizeof (MYSQL_BIND));
+      mysqlP->lengths = calloc (mysqlP->num_fields, sizeof (unsigned long));
+      mysqlP->is_null = calloc (mysqlP->num_fields, sizeof (my_bool));
+
+      if (NULL == mysqlP->result_bind || NULL == mysqlP->lengths || NULL == mysqlP->is_null)
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result_bind start: out of memory"));
+          free_binds (mysqlP->result_bind, 0);
+          goto cleanup_stmt;
+        }
+
+      mysqlP->meta = mysql_stmt_result_metadata (mysqlP->stmt);
+      if (NULL == mysqlP->meta)
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result metadata error"));
+          goto cleanup_stmt;
+        }
+
+      MYSQL_FIELD *fields = mysql_fetch_fields (mysqlP->meta);
+      if (NULL == fields)
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("fetch fields error"));
+          goto cleanup_meta;
+        }
+
+      for (i = 0; i < mysqlP->num_fields; i++)
+        {
+          MYSQL_FIELD *fld = &fields[i];
+          MYSQL_BIND *b = &mysqlP->result_bind[i];
+
+          b->is_null = &mysqlP->is_null[i];
+          b->length = &mysqlP->lengths[i];
+
+          switch (fld->type)
+            {
+            case MYSQL_TYPE_TINY:
+              b->buffer_type = MYSQL_TYPE_TINY;
+              b->buffer = calloc (1, sizeof (int8_t));
+              b->buffer_length = sizeof (int8_t);
+              break;
+
+            case MYSQL_TYPE_SHORT:
+              b->buffer_type = MYSQL_TYPE_SHORT;
+              b->buffer = calloc (1, sizeof (int16_t));
+              b->buffer_length = sizeof (int16_t);
+              break;
+
+            case MYSQL_TYPE_LONG:
+            case MYSQL_TYPE_INT24:
+              b->buffer_type = MYSQL_TYPE_LONG;
+              b->buffer = calloc (1, sizeof (int32_t));
+              b->buffer_length = sizeof (int32_t);
+              break;
+
+            case MYSQL_TYPE_LONGLONG:
+              b->buffer_type = MYSQL_TYPE_LONGLONG;
+              b->buffer = calloc (1, sizeof (int64_t));
+              b->buffer_length = sizeof (int64_t);
+              break;
+
+            case MYSQL_TYPE_FLOAT:
+              b->buffer_type = MYSQL_TYPE_FLOAT;
+              b->buffer = calloc (1, sizeof (float));
+              b->buffer_length = sizeof (float);
+              break;
+
+            case MYSQL_TYPE_DOUBLE:
+              b->buffer_type = MYSQL_TYPE_DOUBLE;
+              b->buffer = calloc (1, sizeof (double));
+              b->buffer_length = sizeof (double);
+              break;
+
+            case MYSQL_TYPE_NEWDECIMAL:
+            case MYSQL_TYPE_STRING:
+            case MYSQL_TYPE_VAR_STRING:
+            case MYSQL_TYPE_VARCHAR:
+            default:
+              b->buffer_type = MYSQL_TYPE_STRING;
+              b->buffer_length = fld->length + 1;
+              b->buffer = calloc (1, b->buffer_length);
+              break;
+            }
+
+          if (NULL == b->buffer)
+            {
+              dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result bind: out of memory"));
+              goto cleanup_result_bind;
+            }
+        }
+
+      if (mysql_stmt_bind_result (mysqlP->stmt, mysqlP->result_bind) != 0)
+        {
+          dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result bind mismatch"));
+          goto cleanup_stmt;
+        }
     }
-
-    mysqlP->meta = mysql_stmt_result_metadata (mysqlP->stmt);
-    if (NULL == mysqlP->meta)
-    {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result metadata error"));
-      goto cleanup_stmt;
-    }
-
-    MYSQL_FIELD *fields = mysql_fetch_fields (mysqlP->meta);
-    if (NULL == fields)
-    {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("fetch fields error"));
-      goto cleanup_meta;
-    }
-
-    for (i = 0; i < mysqlP->num_fields; i++)
-    {
-      MYSQL_FIELD *fld = &fields[i];
-      MYSQL_BIND *b = &mysqlP->result_bind[i];
-
-      b->is_null = &mysqlP->is_null[i];
-      b->length = &mysqlP->lengths[i];
-
-      switch (fld->type)
-      {
-      case MYSQL_TYPE_TINY:
-        b->buffer_type = MYSQL_TYPE_TINY;
-        b->buffer = calloc (1, sizeof (int8_t));
-        b->buffer_length = sizeof (int8_t);
-        break;
-
-      case MYSQL_TYPE_SHORT:
-        b->buffer_type = MYSQL_TYPE_SHORT;
-        b->buffer = calloc (1, sizeof (int16_t));
-        b->buffer_length = sizeof (int16_t);
-        break;
-
-      case MYSQL_TYPE_LONG:
-      case MYSQL_TYPE_INT24:
-        b->buffer_type = MYSQL_TYPE_LONG;
-        b->buffer = calloc (1, sizeof (int32_t));
-        b->buffer_length = sizeof (int32_t);
-        break;
-
-      case MYSQL_TYPE_LONGLONG:
-        b->buffer_type = MYSQL_TYPE_LONGLONG;
-        b->buffer = calloc (1, sizeof (int64_t));
-        b->buffer_length = sizeof (int64_t);
-        break;
-
-      case MYSQL_TYPE_FLOAT:
-        b->buffer_type = MYSQL_TYPE_FLOAT;
-        b->buffer = calloc (1, sizeof (float));
-        b->buffer_length = sizeof (float);
-        break;
-
-      case MYSQL_TYPE_DOUBLE:
-        b->buffer_type = MYSQL_TYPE_DOUBLE;
-        b->buffer = calloc (1, sizeof (double));
-        b->buffer_length = sizeof (double);
-        break;
-
-      case MYSQL_TYPE_NEWDECIMAL:
-      case MYSQL_TYPE_STRING:
-      case MYSQL_TYPE_VAR_STRING:
-      case MYSQL_TYPE_VARCHAR:
-      default:
-        b->buffer_type = MYSQL_TYPE_STRING;
-        b->buffer_length = fld->length + 1;
-        b->buffer = calloc (1, b->buffer_length);
-        break;
-      }
-
-      if (NULL == b->buffer)
-      {
-        dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result bind: out of memory"));
-        goto cleanup_result_bind;
-      }
-    }
-
-    if (mysql_stmt_bind_result (mysqlP->stmt, mysqlP->result_bind) != 0)
-    {
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string ("result bind mismatch"));
-      goto cleanup_stmt;
-    }
-  }
 
   mysqlP->retn = mysql_stmt_affected_rows (mysqlP->stmt);
-  mysqlP->affected_rows = mysqlP->retn;
+  dbh->affected_rows = mysqlP->retn;
   dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
 
-cleanup_params:
+ cleanup_params:
   i = 0;
   while (str[i])
-  {
-    free (str[i]);
-    i++;
-  }
+    {
+      free (str[i]);
+      i++;
+    }
   free (params_bind);
   params_bind = NULL;
 
   return;
 
-cleanup_result_bind:
+ cleanup_result_bind:
   free_binds (mysqlP->result_bind, mysqlP->num_fields);
   mysqlP->result_bind = NULL;
   free (mysqlP->is_null);
@@ -789,19 +788,19 @@ cleanup_result_bind:
   free (mysqlP->lengths);
   mysqlP->lengths = NULL;
 
-cleanup_meta:
+ cleanup_meta:
   if (mysqlP->meta)
-  {
-    mysql_free_result (mysqlP->meta);
-    mysqlP->meta = NULL;
-  }
+    {
+      mysql_free_result (mysqlP->meta);
+      mysqlP->meta = NULL;
+    }
 
-cleanup_stmt:
+ cleanup_stmt:
   if (mysqlP->stmt)
-  {
-    mysql_stmt_close (mysqlP->stmt);
-    mysqlP->stmt = NULL;
-  }
+    {
+      mysql_stmt_close (mysqlP->stmt);
+      mysqlP->stmt = NULL;
+    }
 
   mysqlP->retn = 0;
 
@@ -810,8 +809,5 @@ cleanup_stmt:
 
 int __mysql_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
 {
-  gdbi_mysql_ds_t *mysqlP = (gdbi_mysql_ds_t *)dbh->db_info;
-  if (mysqlP == NULL)
-    return 0;
-  return mysqlP->affected_rows;
+  return dbh->affected_rows;
 }

--- a/guile-dbd-mysql/src/guile-dbd-mysql.c
+++ b/guile-dbd-mysql/src/guile-dbd-mysql.c
@@ -806,8 +806,3 @@ void __mysql_params_query_g_db_handle (gdbi_db_handle_t *dbh, const char *query,
 
   return;
 }
-
-int __mysql_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
-{
-  return dbh->affected_rows;
-}

--- a/guile-dbd-mysql/src/guile-dbd-mysql.c
+++ b/guile-dbd-mysql/src/guile-dbd-mysql.c
@@ -67,6 +67,7 @@ typedef struct
   unsigned int num_fields;
 
   int retn;
+  int affected_rows;
 } gdbi_mysql_ds_t;
 
 static void free_binds (MYSQL_BIND *binds, int cnt)
@@ -310,6 +311,8 @@ void __mysql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
       = scm_cons (scm_from_int (mysqlP->mysql->net.last_errno), scm_from_locale_string (mysql_error (mysqlP->mysql)));
     return;
   }
+
+  mysqlP->affected_rows = mysql_affected_rows (mysqlP->mysql);
 
   mysqlP->res = mysql_use_result (mysqlP->mysql);
   if (mysqlP->res == NULL)
@@ -657,6 +660,8 @@ void __mysql_params_query_g_db_handle (gdbi_db_handle_t *dbh, const char *query,
     goto cleanup_params;
   }
 
+  mysqlP->affected_rows = mysql_stmt_affected_rows (mysqlP->stmt);
+
   /* -------- prepare result fetching -------- */
 
   mysqlP->num_fields = mysql_stmt_field_count (mysqlP->stmt);
@@ -761,6 +766,7 @@ void __mysql_params_query_g_db_handle (gdbi_db_handle_t *dbh, const char *query,
   }
 
   mysqlP->retn = mysql_stmt_affected_rows (mysqlP->stmt);
+  mysqlP->affected_rows = mysqlP->retn;
   dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
 
 cleanup_params:
@@ -800,4 +806,12 @@ cleanup_stmt:
   mysqlP->retn = 0;
 
   return;
+}
+
+int __mysql_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
+{
+  gdbi_mysql_ds_t *mysqlP = (gdbi_mysql_ds_t *)dbh->db_info;
+  if (mysqlP == NULL)
+    return 0;
+  return mysqlP->affected_rows;
 }

--- a/guile-dbd-mysql/test/test-guile-dbd-mysql.scm
+++ b/guile-dbd-mysql/test/test-guile-dbd-mysql.scm
@@ -132,6 +132,152 @@
 (define count-row (dbi-get_row db-obj))
 (check "get count" (cdr (assoc "cnt" count-row)) 3)
 
+;; Test 1: affected_rows after single INSERT
+(check-status "insert single row for affected_rows"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (1, 'Alice')")
+    db-obj))
+
+(define affected-after-single-insert (dbi-affected-rows db-obj))
+(if (not (= affected-after-single-insert 1))
+    (begin
+      (display ";;; affected_rows after single insert FAILED: ")
+      (display "(expected 1 got ")
+      (display affected-after-single-insert)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after single insert PASSED")
+      (newline)))
+
+;; Test 2: affected_rows after multiple INSERT
+(check-status "insert multiple rows for affected_rows"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (2, 'Bob'), (3, 'Carol'), (4, 'Dave')")
+    db-obj))
+
+(define affected-after-multi-insert (dbi-affected-rows db-obj))
+(if (not (= affected-after-multi-insert 3))
+    (begin
+      (display ";;; affected_rows after multiple inserts FAILED: ")
+      (display "(expected 3 got ")
+      (display affected-after-multi-insert)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after multiple inserts PASSED")
+      (newline)))
+
+;; Test 3: affected_rows after UPDATE
+(check-status "update rows for affected_rows"
+  (begin
+    (dbi-query db-obj "UPDATE dbi_test_table SET name = 'Updated' WHERE id IN (2, 3)")
+    db-obj))
+
+(define affected-after-update (dbi-affected-rows db-obj))
+(if (not (= affected-after-update 2))
+    (begin
+      (display ";;; affected_rows after update FAILED: ")
+      (display "(expected 2 got ")
+      (display affected-after-update)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after update PASSED")
+      (newline)))
+
+;; Test 4: affected_rows when UPDATE matches no rows
+(check-status "update no matching rows for affected_rows"
+  (begin
+    (dbi-query db-obj "UPDATE dbi_test_table SET name = 'None' WHERE id = 999")
+    db-obj))
+
+(define affected-after-no-match (dbi-affected-rows db-obj))
+(if (not (= affected-after-no-match 0))
+    (begin
+      (display ";;; affected_rows when update matches nothing FAILED: ")
+      (display "(expected 0 got ")
+      (display affected-after-no-match)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows when update matches nothing PASSED")
+      (newline)))
+
+;; Test 5: affected_rows after DELETE
+(check-status "delete row for affected_rows"
+  (begin
+    (dbi-query db-obj "DELETE FROM dbi_test_table WHERE id = 1")
+    db-obj))
+
+(define affected-after-delete (dbi-affected-rows db-obj))
+(if (not (= affected-after-delete 1))
+    (begin
+      (display ";;; affected_rows after delete FAILED: ")
+      (display "(expected 1 got ")
+      (display affected-after-delete)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after delete PASSED")
+      (newline)))
+
+;; Drop table to clean up before next tests
+(dbi-query db-obj "DROP TABLE IF EXISTS dbi_test_table")
+(dbi-query db-obj "CREATE TABLE dbi_test_table (id INTEGER, name VARCHAR(50))")
+
+;; Test 6: affected_rows after SELECT (should be 0)
+(check-status "select for affected_rows"
+  (begin
+    (dbi-query db-obj "SELECT * FROM dbi_test_table")
+    db-obj))
+
+(define affected-after-select (dbi-affected-rows db-obj))
+;; NOTE:
+;; According to MariaDB doc:
+;; - For statements which return a result set (such as SELECT, SHOW, DESC or
+;;   HELP), returns -1, even when the result set is empty. This is also true
+;;   for administrative statements, such as OPTIMIZE.
+;; https://mariadb.com/docs/server/reference/sql-functions/secondary-functions/information-functions/row_count
+(if (not (= affected-after-select -1))
+    (begin
+      (display ";;; affected_rows after select FAILED: ")
+      (display "(expected 0 got ")
+      (display affected-after-select)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after select PASSED")
+      (newline)))
+
+;; Test 7: affected_rows updates with each query
+(check-status "first insert for sequence test"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (10, 'Test1')")
+    db-obj))
+
+(define first-affected (dbi-affected-rows db-obj))
+
+(check-status "second insert for sequence test"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (11, 'Test2'), (12, 'Test3')")
+    db-obj))
+
+(define second-affected (dbi-affected-rows db-obj))
+
+(if (not (and (= first-affected 1) (= second-affected 2)))
+    (begin
+      (display ";;; affected_rows updates after each query FAILED: ")
+      (display "(expected first=1 second=2, got first=")
+      (display first-affected)
+      (display " second=")
+      (display second-affected)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows updates after each query PASSED")
+      (newline)))
+
 ;; Clean up
 (dbi-query db-obj "DROP TABLE dbi_test_table")
 (dbi-close db-obj)

--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -264,7 +264,7 @@ void __postgresql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
     {
       dbh->status
         = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
-      dbh->affected_rows = atoi (PQcmdTuples (pgsqlP->res));
+      dbh->affected_rows = atoll (PQcmdTuples (pgsqlP->res));
     }
   else
     {
@@ -272,11 +272,6 @@ void __postgresql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
       PQclear (pgsqlP->res);
       pgsqlP->res = NULL;
     }
-}
-
-int __postgresql_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
-{
-  return dbh->affected_rows;
 }
 
 static SCM getrow_for_params (gdbi_db_handle_t *dbh)
@@ -744,7 +739,7 @@ void __postgresql_params_query_g_db_handle (gdbi_db_handle_t *g_db_handle,
     {
       g_db_handle->status
         = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
-      g_db_handle->affected_rows = atoi (PQcmdTuples (res));
+      g_db_handle->affected_rows = atoll (PQcmdTuples (res));
       pgsqlP->lget = 0;
       pgsqlP->is_params = 1;
       /* clear previous result before assigning new one */

--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -44,6 +44,7 @@ typedef struct
   int lget;
   int retn;
   int is_params; /* 1 = came from PQexecParams, 0 = came from PQexec */
+  int affected_rows;
 } gdbi_pgsql_ds_t;
 
 static void dbi_set_error (gdbi_db_handle_t *dbh, const char *msg)
@@ -264,6 +265,7 @@ void __postgresql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
   {
     dbh->status
       = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
+    pgsqlP->affected_rows = atoi (PQcmdTuples (pgsqlP->res));
   }
   else
   {
@@ -271,6 +273,14 @@ void __postgresql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
     PQclear (pgsqlP->res);
     pgsqlP->res = NULL;
   }
+}
+
+int __postgresql_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
+{
+  gdbi_pgsql_ds_t *pgsqlP = (gdbi_pgsql_ds_t *)dbh->db_info;
+  if (pgsqlP == NULL)
+    return 0;
+  return pgsqlP->affected_rows;
 }
 
 static SCM getrow_for_params (gdbi_db_handle_t *dbh)
@@ -738,6 +748,7 @@ cleanup:
   {
     g_db_handle->status
       = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
+    pgsqlP->affected_rows = atoi (PQcmdTuples (res));
     pgsqlP->lget = 0;
     pgsqlP->is_params = 1;
     /* clear previous result before assigning new one */

--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -44,7 +44,6 @@ typedef struct
   int lget;
   int retn;
   int is_params; /* 1 = came from PQexecParams, 0 = came from PQexec */
-  int affected_rows;
 } gdbi_pgsql_ds_t;
 
 static void dbi_set_error (gdbi_db_handle_t *dbh, const char *msg)
@@ -60,122 +59,122 @@ void __postgresql_make_g_db_handle (gdbi_db_handle_t *dbh)
   SCM cp_list = SCM_EOL;
 
   if (scm_equal_p (scm_string_p (dbh->constr), SCM_BOOL_F) == SCM_BOOL_T)
-  {
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_utf8_string ("missing connection string"));
-    return;
-  }
+    {
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_utf8_string ("missing connection string"));
+      return;
+    }
 
   cp_list = scm_string_split (dbh->constr, SCM_MAKE_CHAR (sep));
 
   items = scm_to_int (scm_length (cp_list));
   if (items >= 5 && items < 8)
-  {
-    char *port = NULL;
-    char *user, *pass, *db, *ctyp, *loc;
+    {
+      char *port = NULL;
+      char *user, *pass, *db, *ctyp, *loc;
 
-    pgsqlP = (gdbi_pgsql_ds_t *)malloc (sizeof (gdbi_pgsql_ds_t));
-    if (pgsqlP == NULL)
-    {
-      dbh->status = scm_cons (scm_from_int (errno),
-                              scm_from_locale_string (strerror (errno)));
-      return;
-    }
-    pgsqlP->retn = 0;
+      pgsqlP = (gdbi_pgsql_ds_t *)malloc (sizeof (gdbi_pgsql_ds_t));
+      if (pgsqlP == NULL)
+        {
+          dbh->status = scm_cons (scm_from_int (errno),
+                                  scm_from_locale_string (strerror (errno)));
+          return;
+        }
+      pgsqlP->retn = 0;
 
-    user = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (0)));
-    pass = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (1)));
-    db = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (2)));
-    ctyp = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (3)));
-    loc = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (4)));
+      user = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (0)));
+      pass = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (1)));
+      db = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (2)));
+      ctyp = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (3)));
+      loc = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (4)));
 
-    pgsqlP->pgsql = NULL;
-    pgsqlP->res = NULL;
-
-    if (strcmp (ctyp, "tcp") == 0)
-    {
-      port = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
-      pgsqlP->pgsql
-        = (PGconn *)PQsetdbLogin (loc, port, NULL, NULL, db, user, pass);
-      if (items == 7)
-      {
-        char *sretn
-          = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (6)));
-        pgsqlP->retn = atoi (sretn);
-        free (sretn);
-      }
-    }
-    else
-    {
-      pgsqlP->pgsql
-        = (PGconn *)PQsetdbLogin (loc, NULL, NULL, NULL, db, user, pass);
-      if (items == 6)
-      {
-        char *sretn
-          = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
-        pgsqlP->retn = atoi (sretn);
-        free (sretn);
-      }
-    }
-
-    /* free resources */
-    if (user)
-    {
-      free (user);
-    }
-    if (pass)
-    {
-      free (pass);
-    }
-    if (db)
-    {
-      free (db);
-    }
-    if (ctyp)
-    {
-      free (ctyp);
-    }
-    if (loc)
-    {
-      free (loc);
-    }
-    if (port)
-    {
-      free (port);
-    }
-
-    if (PQstatus (pgsqlP->pgsql) == CONNECTION_BAD)
-    {
-      dbh->status
-        = scm_cons (scm_from_int (1),
-                    scm_from_locale_string (PQerrorMessage (pgsqlP->pgsql)));
-      PQfinish (pgsqlP->pgsql);
       pgsqlP->pgsql = NULL;
-      free (pgsqlP);
+      pgsqlP->res = NULL;
+
+      if (strcmp (ctyp, "tcp") == 0)
+        {
+          port = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
+          pgsqlP->pgsql
+            = (PGconn *)PQsetdbLogin (loc, port, NULL, NULL, db, user, pass);
+          if (items == 7)
+            {
+              char *sretn
+                = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (6)));
+              pgsqlP->retn = atoi (sretn);
+              free (sretn);
+            }
+        }
+      else
+        {
+          pgsqlP->pgsql
+            = (PGconn *)PQsetdbLogin (loc, NULL, NULL, NULL, db, user, pass);
+          if (items == 6)
+            {
+              char *sretn
+                = scm_to_locale_string (scm_list_ref (cp_list, scm_from_int (5)));
+              pgsqlP->retn = atoi (sretn);
+              free (sretn);
+            }
+        }
+
+      /* free resources */
+      if (user)
+        {
+          free (user);
+        }
+      if (pass)
+        {
+          free (pass);
+        }
+      if (db)
+        {
+          free (db);
+        }
+      if (ctyp)
+        {
+          free (ctyp);
+        }
+      if (loc)
+        {
+          free (loc);
+        }
+      if (port)
+        {
+          free (port);
+        }
+
+      if (PQstatus (pgsqlP->pgsql) == CONNECTION_BAD)
+        {
+          dbh->status
+            = scm_cons (scm_from_int (1),
+                        scm_from_locale_string (PQerrorMessage (pgsqlP->pgsql)));
+          PQfinish (pgsqlP->pgsql);
+          pgsqlP->pgsql = NULL;
+          free (pgsqlP);
+          dbh->db_info = NULL;
+          dbh->closed = SCM_BOOL_T;
+          return;
+        }
+      else
+        {
+          /* todo: error msg to be translated */
+          dbh->status
+            = scm_cons (scm_from_int (0), scm_from_utf8_string ("db connected"));
+          dbh->db_info = pgsqlP;
+          dbh->closed = SCM_BOOL_F;
+          return;
+        }
+    }
+  else
+    {
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_utf8_string ("invalid connection string"));
       dbh->db_info = NULL;
       dbh->closed = SCM_BOOL_T;
       return;
     }
-    else
-    {
-      /* todo: error msg to be translated */
-      dbh->status
-        = scm_cons (scm_from_int (0), scm_from_utf8_string ("db connected"));
-      dbh->db_info = pgsqlP;
-      dbh->closed = SCM_BOOL_F;
-      return;
-    }
-  }
-  else
-  {
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_utf8_string ("invalid connection string"));
-    dbh->db_info = NULL;
-    dbh->closed = SCM_BOOL_T;
-    return;
-  }
 
   return;
 }
@@ -184,38 +183,38 @@ void __postgresql_close_g_db_handle (gdbi_db_handle_t *dbh)
 {
   gdbi_pgsql_ds_t *pgsqlP = (gdbi_pgsql_ds_t *)dbh->db_info;
   if (pgsqlP == NULL)
-  {
-    if (dbh->in_free)
-      return; /* don't scm anything if in GC */
-    /* todo: error msg to be translated */
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_utf8_string ("dbd info not found"));
-    return;
-  }
+    {
+      if (dbh->in_free)
+        return; /* don't scm anything if in GC */
+      /* todo: error msg to be translated */
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_utf8_string ("dbd info not found"));
+      return;
+    }
 
   /* Don't scm anything if we are in garbage collection */
   if (0 == dbh->in_free)
-  {
-    if (NULL == pgsqlP->pgsql)
     {
-      /* todo: error msg to be translated */
-      dbh->status
-        = scm_cons (scm_from_int (1),
-                    scm_from_utf8_string ("dbi connection already closed"));
+      if (NULL == pgsqlP->pgsql)
+        {
+          /* todo: error msg to be translated */
+          dbh->status
+            = scm_cons (scm_from_int (1),
+                        scm_from_utf8_string ("dbi connection already closed"));
+        }
+      else
+        {
+          dbh->status
+            = scm_cons (scm_from_int (0), scm_from_utf8_string ("dbi closed"));
+        }
     }
-    else
-    {
-      dbh->status
-        = scm_cons (scm_from_int (0), scm_from_utf8_string ("dbi closed"));
-    }
-  }
 
   PQfinish (pgsqlP->pgsql);
   if (pgsqlP->res)
-  {
-    PQclear (pgsqlP->res);
-    pgsqlP->res = NULL;
-  }
+    {
+      PQclear (pgsqlP->res);
+      pgsqlP->res = NULL;
+    }
 
   free (dbh->db_info);
   dbh->db_info = NULL;
@@ -228,59 +227,56 @@ void __postgresql_query_g_db_handle (gdbi_db_handle_t *dbh, char *query)
   gdbi_pgsql_ds_t *pgsqlP = NULL;
 
   if (dbh->db_info == NULL)
-  {
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_utf8_string ("invalid dbi connection"));
-    return;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_utf8_string ("invalid dbi connection"));
+      return;
+    }
 
   if (query == NULL)
-  {
-    dbh->status
-      = scm_cons (scm_from_int (1), scm_from_utf8_string ("invalid dbi query"));
-    return;
-  }
+    {
+      dbh->status
+        = scm_cons (scm_from_int (1), scm_from_utf8_string ("invalid dbi query"));
+      return;
+    }
 
   pgsqlP = (gdbi_pgsql_ds_t *)dbh->db_info;
 
   /* clear any previous result */
   if (pgsqlP->res)
-  {
-    PQclear (pgsqlP->res);
-    pgsqlP->res = NULL;
-  }
+    {
+      PQclear (pgsqlP->res);
+      pgsqlP->res = NULL;
+    }
 
   pgsqlP->res = PQexec (pgsqlP->pgsql, query);
   pgsqlP->lget = 0;
   pgsqlP->is_params = 0;
 
   if (NULL == pgsqlP->res)
-  {
-    dbi_set_error (dbh, PQerrorMessage (pgsqlP->pgsql));
-    return;
-  }
+    {
+      dbi_set_error (dbh, PQerrorMessage (pgsqlP->pgsql));
+      return;
+    }
 
   ExecStatusType st = PQresultStatus (pgsqlP->res);
   if (st == PGRES_COMMAND_OK || st == PGRES_TUPLES_OK)
-  {
-    dbh->status
-      = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
-    pgsqlP->affected_rows = atoi (PQcmdTuples (pgsqlP->res));
-  }
+    {
+      dbh->status
+        = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
+      dbh->affected_rows = atoi (PQcmdTuples (pgsqlP->res));
+    }
   else
-  {
-    dbi_set_error (dbh, PQresultErrorMessage (pgsqlP->res));
-    PQclear (pgsqlP->res);
-    pgsqlP->res = NULL;
-  }
+    {
+      dbi_set_error (dbh, PQresultErrorMessage (pgsqlP->res));
+      PQclear (pgsqlP->res);
+      pgsqlP->res = NULL;
+    }
 }
 
 int __postgresql_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
 {
-  gdbi_pgsql_ds_t *pgsqlP = (gdbi_pgsql_ds_t *)dbh->db_info;
-  if (pgsqlP == NULL)
-    return 0;
-  return pgsqlP->affected_rows;
+  return dbh->affected_rows;
 }
 
 static SCM getrow_for_params (gdbi_db_handle_t *dbh)
@@ -290,171 +286,171 @@ static SCM getrow_for_params (gdbi_db_handle_t *dbh)
   int fnum, f;
 
   if (NULL == pgsqlP->res)
-  {
-    dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
-    return SCM_BOOL_F;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
+      return SCM_BOOL_F;
+    }
 
   if (pgsqlP->lget >= PQntuples (pgsqlP->res))
-  {
-    PQclear (pgsqlP->res);
-    pgsqlP->res = NULL;
-    pgsqlP->lget = 0;
-    pgsqlP->is_params = 0;
-    dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
-    return SCM_BOOL_F;
-  }
+    {
+      PQclear (pgsqlP->res);
+      pgsqlP->res = NULL;
+      pgsqlP->lget = 0;
+      pgsqlP->is_params = 0;
+      dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
+      return SCM_BOOL_F;
+    }
 
   fnum = PQnfields (pgsqlP->res);
 
   for (f = 0; f < fnum; f++)
-  {
-    SCM value;
-    const char *fname = PQfname (pgsqlP->res, f);
-    Oid type = PQftype (pgsqlP->res, f);
-
-    /* NULL — mirrors MySQL getrow_for_stmt is_null[f] check */
-    if (PQgetisnull (pgsqlP->res, pgsqlP->lget, f))
     {
-      value = SCM_UNSPECIFIED;
-      retrow = scm_append (scm_list_2 (
-        retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
-      continue;
-    }
+      SCM value;
+      const char *fname = PQfname (pgsqlP->res, f);
+      Oid type = PQftype (pgsqlP->res, f);
 
-    const char *vstr = PQgetvalue (pgsqlP->res, pgsqlP->lget, f);
-    size_t vlen = PQgetlength (pgsqlP->res, pgsqlP->lget, f);
-
-    switch (type)
-    {
-    /* bool → scm_from_bool, mirrors MYSQL_TYPE_TINY 1/0 */
-    case BOOLOID:
-      value = scm_from_bool (vstr[0] == 't');
-      break;
-
-    /* smallint → scm_from_int, mirrors MYSQL_TYPE_SHORT */
-    case INT2OID:
-      value = scm_from_int (atoi (vstr));
-      break;
-
-    /* integer / regproc / oid → scm_from_int, mirrors MYSQL_TYPE_LONG */
-    case INT4OID:
-    case 24: /* regproc */
-    case 26: /* oid */
-      value = scm_from_int (atoi (vstr));
-      break;
-
-    /* bigint → scm_from_int64, mirrors MYSQL_TYPE_LONGLONG */
-    case INT8OID:
-      value = scm_from_int64 (atoll (vstr));
-      break;
-
-    /* float4 → double, mirrors MYSQL_TYPE_FLOAT */
-    case FLOAT4OID:
-      value = scm_from_double (atof (vstr));
-      break;
-
-    /* float8 → double, mirrors MYSQL_TYPE_DOUBLE */
-    case FLOAT8OID:
-      value = scm_from_double (atof (vstr));
-      break;
-
-    /* numeric/decimal → string, mirrors MySQL stmt NEWDECIMAL as string */
-    case NUMERICOID:
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    /* money → string */
-    case MONEYOID:
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    /* integer arrays → SCM list, mirrors no MySQL equivalent but
-       keep consistent with PQexec path above */
-    case INT2ARRAYOID: /* _int2 */
-    case INT4ARRAYOID: /* _int4 */
-    case INT8ARRAYOID: /* _int8 */
-    {
-      char *p = strdup (vstr + 1); /* skip '{' */
-      char *end = strrchr (p, '}');
-      if (end)
-        *end = '\0';
-      value = SCM_EOL;
-      if (p[0] != '\0')
-      {
-        char *tok = strrchr (p, ',');
-        while (tok)
+      /* NULL — mirrors MySQL getrow_for_stmt is_null[f] check */
+      if (PQgetisnull (pgsqlP->res, pgsqlP->lget, f))
         {
-          value = scm_cons (scm_from_int64 (atoll (tok + 1)), value);
-          *tok = '\0';
-          tok = strrchr (p, ',');
+          value = SCM_UNSPECIFIED;
+          retrow = scm_append (scm_list_2 (
+                                           retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
+          continue;
         }
-        value = scm_cons (scm_from_int64 (atoll (p)), value);
-      }
-      free (p);
-      break;
+
+      const char *vstr = PQgetvalue (pgsqlP->res, pgsqlP->lget, f);
+      size_t vlen = PQgetlength (pgsqlP->res, pgsqlP->lget, f);
+
+      switch (type)
+        {
+          /* bool → scm_from_bool, mirrors MYSQL_TYPE_TINY 1/0 */
+        case BOOLOID:
+          value = scm_from_bool (vstr[0] == 't');
+          break;
+
+          /* smallint → scm_from_int, mirrors MYSQL_TYPE_SHORT */
+        case INT2OID:
+          value = scm_from_int (atoi (vstr));
+          break;
+
+          /* integer / regproc / oid → scm_from_int, mirrors MYSQL_TYPE_LONG */
+        case INT4OID:
+        case 24: /* regproc */
+        case 26: /* oid */
+          value = scm_from_int (atoi (vstr));
+          break;
+
+          /* bigint → scm_from_int64, mirrors MYSQL_TYPE_LONGLONG */
+        case INT8OID:
+          value = scm_from_int64 (atoll (vstr));
+          break;
+
+          /* float4 → double, mirrors MYSQL_TYPE_FLOAT */
+        case FLOAT4OID:
+          value = scm_from_double (atof (vstr));
+          break;
+
+          /* float8 → double, mirrors MYSQL_TYPE_DOUBLE */
+        case FLOAT8OID:
+          value = scm_from_double (atof (vstr));
+          break;
+
+          /* numeric/decimal → string, mirrors MySQL stmt NEWDECIMAL as string */
+        case NUMERICOID:
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+          /* money → string */
+        case MONEYOID:
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+          /* integer arrays → SCM list, mirrors no MySQL equivalent but
+             keep consistent with PQexec path above */
+        case INT2ARRAYOID: /* _int2 */
+        case INT4ARRAYOID: /* _int4 */
+        case INT8ARRAYOID: /* _int8 */
+          {
+            char *p = strdup (vstr + 1); /* skip '{' */
+            char *end = strrchr (p, '}');
+            if (end)
+              *end = '\0';
+            value = SCM_EOL;
+            if (p[0] != '\0')
+              {
+                char *tok = strrchr (p, ',');
+                while (tok)
+                  {
+                    value = scm_cons (scm_from_int64 (atoll (tok + 1)), value);
+                    *tok = '\0';
+                    tok = strrchr (p, ',');
+                  }
+                value = scm_cons (scm_from_int64 (atoll (p)), value);
+              }
+            free (p);
+            break;
+          }
+
+          /* bytea → raw string by length, mirrors MySQL BLOB */
+        case BYTEAOID:
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+          /* text-like: char/name/text/bpchar/varchar →
+             scm_from_locale_stringn, mirrors MySQL STRING/VAR_STRING */
+        case CHAROID:
+        case NAMEOID:
+        case TEXTOID:
+        case BPCHAROID:
+        case VARCHAROID:
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+          /* date/time/timestamp → string, mirrors MySQL stmt path which
+             returns string (not strptime — that is only in MySQL legacy path) */
+        case 702: /* abstime (deprecated) */
+        case DATEOID:
+        case TIMEOID:
+        case TIMESTAMPOID:
+        case TIMESTAMPTZOID:
+        case 1266: /* timetz */
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+          /* bit/varbit → string */
+        case 1560: /* bit */
+        case 1562: /* varbit */
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+          /* uuid/json/jsonb → string */
+        case UUIDOID:
+        case JSONOID:
+        case JSONBOID:
+          value = scm_from_locale_stringn (vstr, vlen);
+          break;
+
+        default:
+          {
+            char msg[101];
+            snprintf (msg, 100, "unknown field type %d for %s", type, fname);
+            dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
+            pgsqlP->lget++;
+            return SCM_BOOL_F;
+          }
+        }
+
+      retrow = scm_append (scm_list_2 (
+                                       retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
     }
-
-    /* bytea → raw string by length, mirrors MySQL BLOB */
-    case BYTEAOID:
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    /* text-like: char/name/text/bpchar/varchar →
-       scm_from_locale_stringn, mirrors MySQL STRING/VAR_STRING */
-    case CHAROID:
-    case NAMEOID:
-    case TEXTOID:
-    case BPCHAROID:
-    case VARCHAROID:
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    /* date/time/timestamp → string, mirrors MySQL stmt path which
-       returns string (not strptime — that is only in MySQL legacy path) */
-    case 702: /* abstime (deprecated) */
-    case DATEOID:
-    case TIMEOID:
-    case TIMESTAMPOID:
-    case TIMESTAMPTZOID:
-    case 1266: /* timetz */
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    /* bit/varbit → string */
-    case 1560: /* bit */
-    case 1562: /* varbit */
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    /* uuid/json/jsonb → string */
-    case UUIDOID:
-    case JSONOID:
-    case JSONBOID:
-      value = scm_from_locale_stringn (vstr, vlen);
-      break;
-
-    default:
-    {
-      char msg[101];
-      snprintf (msg, 100, "unknown field type %d for %s", type, fname);
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
-      pgsqlP->lget++;
-      return SCM_BOOL_F;
-    }
-    }
-
-    retrow = scm_append (scm_list_2 (
-      retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
-  }
 
   pgsqlP->lget++;
 
   if (retrow == SCM_EOL)
-  {
-    dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
-    return SCM_BOOL_F;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
+      return SCM_BOOL_F;
+    }
 
   dbh->status
     = scm_cons (scm_from_int (0), scm_from_utf8_string ("row fetched"));
@@ -468,11 +464,11 @@ SCM __postgresql_getrow_g_db_handle (gdbi_db_handle_t *dbh)
   int fnum, f;
 
   if (dbh->db_info == NULL)
-  {
-    dbh->status = scm_cons (scm_from_int (1),
-                            scm_from_utf8_string ("invalid dbi connection"));
-    return SCM_BOOL_F;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (1),
+                              scm_from_utf8_string ("invalid dbi connection"));
+      return SCM_BOOL_F;
+    }
 
   pgsqlP = (gdbi_pgsql_ds_t *)dbh->db_info;
 
@@ -486,170 +482,170 @@ SCM __postgresql_getrow_g_db_handle (gdbi_db_handle_t *dbh)
      The old lazy PQgetResult call is removed — it was only needed for the
      old async PQsendQuery path which is now gone. */
   if (NULL == pgsqlP->res)
-  {
-    dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
-    return SCM_BOOL_F;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
+      return SCM_BOOL_F;
+    }
 
   if (pgsqlP->lget >= PQntuples (pgsqlP->res))
-  {
-    pgsqlP->lget = 0;
-    PQclear (pgsqlP->res);
-    pgsqlP->res = NULL;
-    dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
-    return SCM_BOOL_F;
-  }
+    {
+      pgsqlP->lget = 0;
+      PQclear (pgsqlP->res);
+      pgsqlP->res = NULL;
+      dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
+      return SCM_BOOL_F;
+    }
 
   switch (PQresultStatus (pgsqlP->res))
-  {
-  case PGRES_BAD_RESPONSE:
-  case PGRES_NONFATAL_ERROR:
-  case PGRES_FATAL_ERROR:
-    dbh->status = scm_cons (
-      scm_from_int (1),
-      scm_from_locale_string (PQresStatus (PQresultStatus (pgsqlP->res))));
-    return SCM_BOOL_F;
+    {
+    case PGRES_BAD_RESPONSE:
+    case PGRES_NONFATAL_ERROR:
+    case PGRES_FATAL_ERROR:
+      dbh->status = scm_cons (
+                              scm_from_int (1),
+                              scm_from_locale_string (PQresStatus (PQresultStatus (pgsqlP->res))));
+      return SCM_BOOL_F;
 
-  case PGRES_EMPTY_QUERY:
-  case PGRES_COMMAND_OK:
-  case PGRES_TUPLES_OK:
-  case PGRES_COPY_OUT:
-  case PGRES_COPY_IN:
-    dbh->status = scm_cons (
-      scm_from_int (0),
-      scm_from_locale_string (PQresStatus (PQresultStatus (pgsqlP->res))));
-    break;
+    case PGRES_EMPTY_QUERY:
+    case PGRES_COMMAND_OK:
+    case PGRES_TUPLES_OK:
+    case PGRES_COPY_OUT:
+    case PGRES_COPY_IN:
+      dbh->status = scm_cons (
+                              scm_from_int (0),
+                              scm_from_locale_string (PQresStatus (PQresultStatus (pgsqlP->res))));
+      break;
 
-  default:
-    dbh->status = scm_cons (
-      scm_from_int (0), scm_from_utf8_string ("unknown return query status"));
-    break;
-  }
+    default:
+      dbh->status = scm_cons (
+                              scm_from_int (0), scm_from_utf8_string ("unknown return query status"));
+      break;
+    }
 
   fnum = PQnfields (pgsqlP->res);
 
   for (f = 0; f < fnum; f++)
-  {
-    SCM value;
-    Oid type = PQftype (pgsqlP->res, f);
-    const char *fname = PQfname (pgsqlP->res, f);
-
-    if (PQgetisnull (pgsqlP->res, pgsqlP->lget, f))
     {
-      value = SCM_UNSPECIFIED;
-      retrow = scm_append (scm_list_2 (
-        retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
-      continue;
-    }
+      SCM value;
+      Oid type = PQftype (pgsqlP->res, f);
+      const char *fname = PQfname (pgsqlP->res, f);
 
-    const char *vstr = PQgetvalue (pgsqlP->res, pgsqlP->lget, f);
-
-    switch (type)
-    {
-    case BOOLOID:
-      value = scm_from_bool (vstr[0] == 't');
-      break;
-
-    case INT8OID:
-      value = scm_from_int64 (atoll (vstr));
-      break;
-
-    case INT2OID:
-    case INT4OID:
-    case 24: /* regproc */
-    case 26: /* oid */
-      value = scm_from_int (atoi (vstr));
-      break;
-
-    case FLOAT4OID:
-    case FLOAT8OID:
-      value = scm_c_locale_stringn_to_number (vstr, strlen (vstr), 10);
-      if (scm_is_false (value))
-        value = scm_from_double (0.0);
-      break;
-
-    case MONEYOID:
-    case NUMERICOID:
-      value = scm_from_locale_string (vstr);
-      break;
-
-    case INT2ARRAYOID:
-    case INT4ARRAYOID:
-    case INT8ARRAYOID:
-    {
-      char *p = strdup (vstr + 1);
-      char *end = strrchr (p, '}');
-      if (end)
-        *end = '\0';
-      value = SCM_EOL;
-      if (p[0] != '\0')
-      {
-        char *tok = strrchr (p, ',');
-        while (tok)
+      if (PQgetisnull (pgsqlP->res, pgsqlP->lget, f))
         {
-          value = scm_cons (scm_from_int64 (atoll (tok + 1)), value);
-          *tok = '\0';
-          tok = strrchr (p, ',');
+          value = SCM_UNSPECIFIED;
+          retrow = scm_append (scm_list_2 (
+                                           retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
+          continue;
         }
-        value = scm_cons (scm_from_int64 (atoll (p)), value);
-      }
-      free (p);
-      break;
+
+      const char *vstr = PQgetvalue (pgsqlP->res, pgsqlP->lget, f);
+
+      switch (type)
+        {
+        case BOOLOID:
+          value = scm_from_bool (vstr[0] == 't');
+          break;
+
+        case INT8OID:
+          value = scm_from_int64 (atoll (vstr));
+          break;
+
+        case INT2OID:
+        case INT4OID:
+        case 24: /* regproc */
+        case 26: /* oid */
+          value = scm_from_int (atoi (vstr));
+          break;
+
+        case FLOAT4OID:
+        case FLOAT8OID:
+          value = scm_c_locale_stringn_to_number (vstr, strlen (vstr), 10);
+          if (scm_is_false (value))
+            value = scm_from_double (0.0);
+          break;
+
+        case MONEYOID:
+        case NUMERICOID:
+          value = scm_from_locale_string (vstr);
+          break;
+
+        case INT2ARRAYOID:
+        case INT4ARRAYOID:
+        case INT8ARRAYOID:
+          {
+            char *p = strdup (vstr + 1);
+            char *end = strrchr (p, '}');
+            if (end)
+              *end = '\0';
+            value = SCM_EOL;
+            if (p[0] != '\0')
+              {
+                char *tok = strrchr (p, ',');
+                while (tok)
+                  {
+                    value = scm_cons (scm_from_int64 (atoll (tok + 1)), value);
+                    *tok = '\0';
+                    tok = strrchr (p, ',');
+                  }
+                value = scm_cons (scm_from_int64 (atoll (p)), value);
+              }
+            free (p);
+            break;
+          }
+
+        case BYTEAOID:
+          {
+            size_t len = PQgetlength (pgsqlP->res, pgsqlP->lget, f);
+            value = scm_from_locale_stringn (vstr, len);
+            break;
+          }
+
+        case CHAROID:
+        case NAMEOID:
+        case TEXTOID:
+        case BPCHAROID:
+        case VARCHAROID:
+          value = scm_from_locale_string (vstr);
+          break;
+
+        case 702: /* abstime (deprecated) */
+        case DATEOID:
+        case TIMEOID:
+        case TIMESTAMPOID:
+        case TIMESTAMPTZOID:
+        case 1266: /* timetz */
+        case 1560: /* bit */
+        case 1562: /* varbit */
+          value = scm_from_locale_string (vstr);
+          break;
+
+        case UUIDOID:
+        case JSONOID:
+        case JSONBOID:
+          value = scm_from_locale_string (vstr);
+          break;
+
+        default:
+          {
+            char msg[101];
+            snprintf (msg, 100, "unknown field type %d for %s", type, fname);
+            dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
+            pgsqlP->lget++;
+            return SCM_BOOL_F;
+          }
+        }
+
+      retrow = scm_append (scm_list_2 (
+                                       retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
     }
-
-    case BYTEAOID:
-    {
-      size_t len = PQgetlength (pgsqlP->res, pgsqlP->lget, f);
-      value = scm_from_locale_stringn (vstr, len);
-      break;
-    }
-
-    case CHAROID:
-    case NAMEOID:
-    case TEXTOID:
-    case BPCHAROID:
-    case VARCHAROID:
-      value = scm_from_locale_string (vstr);
-      break;
-
-    case 702: /* abstime (deprecated) */
-    case DATEOID:
-    case TIMEOID:
-    case TIMESTAMPOID:
-    case TIMESTAMPTZOID:
-    case 1266: /* timetz */
-    case 1560: /* bit */
-    case 1562: /* varbit */
-      value = scm_from_locale_string (vstr);
-      break;
-
-    case UUIDOID:
-    case JSONOID:
-    case JSONBOID:
-      value = scm_from_locale_string (vstr);
-      break;
-
-    default:
-    {
-      char msg[101];
-      snprintf (msg, 100, "unknown field type %d for %s", type, fname);
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
-      pgsqlP->lget++;
-      return SCM_BOOL_F;
-    }
-    }
-
-    retrow = scm_append (scm_list_2 (
-      retrow, scm_list_1 (scm_cons (scm_from_locale_string (fname), value))));
-  }
 
   pgsqlP->lget++;
 
   if (retrow == SCM_EOL)
-  {
-    dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
-    return SCM_BOOL_F;
-  }
+    {
+      dbh->status = scm_cons (scm_from_int (0), scm_from_utf8_string ("row end"));
+      return SCM_BOOL_F;
+    }
 
   dbh->status
     = scm_cons (scm_from_int (0), scm_from_utf8_string ("row fetched"));
@@ -673,53 +669,53 @@ void __postgresql_params_query_g_db_handle (gdbi_db_handle_t *g_db_handle,
   formats = calloc (argc, sizeof (int));
 
   if (NULL == pg_sql || NULL == values || NULL == lengths || NULL == formats)
-  {
-    snprintf (errbuf, sizeof (errbuf),
-              "PostgreSQL parameterized query failed: out of memory");
-    dbi_set_error (g_db_handle, errbuf);
-    goto cleanup;
-  }
-
-  for (int i = 0; i < argc; i++)
-  {
-    SCM v = argv[i];
-    char *s = NULL;
-
-    if (scm_is_null (v))
-    {
-      s = NULL; /* SQL NULL */
-    }
-    else if (scm_is_string (v))
-    {
-      s = scm_to_locale_string (v);
-    }
-    else if (scm_is_number (v))
-    {
-      SCM str = scm_number_to_string (v, scm_from_int (10));
-      s = scm_to_locale_string (str);
-    }
-    else if (scm_is_bool (v))
-    {
-      s = scm_is_true (v) ? strdup ("true") : strdup ("false");
-    }
-    else
     {
       snprintf (errbuf, sizeof (errbuf),
-                "PostgreSQL parameterized query failed: unsupported parameter");
+                "PostgreSQL parameterized query failed: out of memory");
       dbi_set_error (g_db_handle, errbuf);
       goto cleanup;
     }
 
-    values[i] = s;
-    lengths[i] = s ? (int)strlen (s) : 0;
-    formats[i] = 0; /* text */
-  }
+  for (int i = 0; i < argc; i++)
+    {
+      SCM v = argv[i];
+      char *s = NULL;
+
+      if (scm_is_null (v))
+        {
+          s = NULL; /* SQL NULL */
+        }
+      else if (scm_is_string (v))
+        {
+          s = scm_to_locale_string (v);
+        }
+      else if (scm_is_number (v))
+        {
+          SCM str = scm_number_to_string (v, scm_from_int (10));
+          s = scm_to_locale_string (str);
+        }
+      else if (scm_is_bool (v))
+        {
+          s = scm_is_true (v) ? strdup ("true") : strdup ("false");
+        }
+      else
+        {
+          snprintf (errbuf, sizeof (errbuf),
+                    "PostgreSQL parameterized query failed: unsupported parameter");
+          dbi_set_error (g_db_handle, errbuf);
+          goto cleanup;
+        }
+
+      values[i] = s;
+      lengths[i] = s ? (int)strlen (s) : 0;
+      formats[i] = 0; /* text */
+    }
 
   res = PQexecParams (pgsqlP->pgsql, pg_sql, argc,
                       NULL, /* let PostgreSQL infer types */
                       values, lengths, formats, 0); /* text results */
 
-cleanup:
+ cleanup:
   for (int i = 0; i < argc; i++)
     if (values[i])
       free ((char *)values[i]);
@@ -729,41 +725,41 @@ cleanup:
   free (formats);
 
   if (NULL == res)
-  {
-    snprintf (errbuf, sizeof (errbuf), "PostgreSQL execution failed: %s",
-              PQerrorMessage (pgsqlP->pgsql));
-    dbi_set_error (g_db_handle, errbuf);
-    if (pgsqlP->res)
     {
-      PQclear (pgsqlP->res);
+      snprintf (errbuf, sizeof (errbuf), "PostgreSQL execution failed: %s",
+                PQerrorMessage (pgsqlP->pgsql));
+      dbi_set_error (g_db_handle, errbuf);
+      if (pgsqlP->res)
+        {
+          PQclear (pgsqlP->res);
+        }
+      pgsqlP->res = NULL;
+      pgsqlP->lget = 0;
+      pgsqlP->is_params = 0;
+      return;
     }
-    pgsqlP->res = NULL;
-    pgsqlP->lget = 0;
-    pgsqlP->is_params = 0;
-    return;
-  }
 
   ExecStatusType st = PQresultStatus (res);
   if (st == PGRES_COMMAND_OK || st == PGRES_TUPLES_OK)
-  {
-    g_db_handle->status
-      = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
-    pgsqlP->affected_rows = atoi (PQcmdTuples (res));
-    pgsqlP->lget = 0;
-    pgsqlP->is_params = 1;
-    /* clear previous result before assigning new one */
-    if (pgsqlP->res)
     {
-      PQclear (pgsqlP->res);
+      g_db_handle->status
+        = scm_cons (scm_from_int (0), scm_from_utf8_string ("query ok"));
+      g_db_handle->affected_rows = atoi (PQcmdTuples (res));
+      pgsqlP->lget = 0;
+      pgsqlP->is_params = 1;
+      /* clear previous result before assigning new one */
+      if (pgsqlP->res)
+        {
+          PQclear (pgsqlP->res);
+        }
+      pgsqlP->res = res;
     }
-    pgsqlP->res = res;
-  }
   else
-  {
-    dbi_set_error (g_db_handle, PQresultErrorMessage (res));
-    PQclear (res);
-    pgsqlP->res = NULL;
-    pgsqlP->lget = 0;
-    pgsqlP->is_params = 0;
-  }
+    {
+      dbi_set_error (g_db_handle, PQresultErrorMessage (res));
+      PQclear (res);
+      pgsqlP->res = NULL;
+      pgsqlP->lget = 0;
+      pgsqlP->is_params = 0;
+    }
 }

--- a/guile-dbd-postgresql/test/test-guile-dbd-postgresql.scm
+++ b/guile-dbd-postgresql/test/test-guile-dbd-postgresql.scm
@@ -86,7 +86,7 @@
 ;; Drop test table if exists (ignore errors)
 (dbi-query db-obj "DROP TABLE IF EXISTS dbi_test_table")
 
-(check-status "create table"
+(check-status "create dbi_test_table"
   (begin
     (dbi-query db-obj "CREATE TABLE dbi_test_table (id INTEGER, name VARCHAR(50))")
     db-obj))
@@ -129,11 +129,148 @@
     (dbi-query db-obj "SELECT COUNT(id) as cnt FROM dbi_test_table")
     db-obj))
 
-(define count-row (dbi-get_row db-obj))
-(check "get count" (cdr (assoc "cnt" count-row)) 3)
+;; Test 1: affected_rows after single INSERT
+(check-status "insert single row for affected_rows"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (1, 'Alice')")
+    db-obj))
 
-;; Clean up
-(dbi-query db-obj "DROP TABLE dbi_test_table")
+(define affected-after-single-insert (dbi-affected-rows db-obj))
+(if (not (= affected-after-single-insert 1))
+    (begin
+      (display ";;; affected_rows after single insert FAILED: ")
+      (display "(expected 1 got ")
+      (display affected-after-single-insert)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after single insert PASSED")
+      (newline)))
+
+;; Test 2: affected_rows after multiple INSERT
+(check-status "insert multiple rows for affected_rows"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (2, 'Bob'), (3, 'Carol'), (4, 'Dave')")
+    db-obj))
+
+(define affected-after-multi-insert (dbi-affected-rows db-obj))
+(if (not (= affected-after-multi-insert 3))
+    (begin
+      (display ";;; affected_rows after multiple inserts FAILED: ")
+      (display "(expected 3 got ")
+      (display affected-after-multi-insert)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after multiple inserts PASSED")
+      (newline)))
+
+;; Test 3: affected_rows after UPDATE
+(check-status "update rows for affected_rows"
+  (begin
+    (dbi-query db-obj "UPDATE dbi_test_table SET name = 'Updated' WHERE id IN (2, 3)")
+    db-obj))
+
+(define affected-after-update (dbi-affected-rows db-obj))
+(if (not (= affected-after-update 2))
+    (begin
+      (display ";;; affected_rows after update FAILED: ")
+      (display "(expected 2 got ")
+      (display affected-after-update)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after update PASSED")
+      (newline)))
+
+;; Test 4: affected_rows when UPDATE matches no rows
+(check-status "update no matching rows for affected_rows"
+  (begin
+    (dbi-query db-obj "UPDATE dbi_test_table SET name = 'None' WHERE id = 999")
+    db-obj))
+
+(define affected-after-no-match (dbi-affected-rows db-obj))
+(if (not (= affected-after-no-match 0))
+    (begin
+      (display ";;; affected_rows when update matches nothing FAILED: ")
+      (display "(expected 0 got ")
+      (display affected-after-no-match)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows when update matches nothing PASSED")
+      (newline)))
+
+;; Test 5: affected_rows after DELETE
+(check-status "delete row for affected_rows"
+  (begin
+    (dbi-query db-obj "DELETE FROM dbi_test_table WHERE id = 1")
+    db-obj))
+
+(define affected-after-delete (dbi-affected-rows db-obj))
+(if (not (= affected-after-delete 1))
+    (begin
+      (display ";;; affected_rows after delete FAILED: ")
+      (display "(expected 1 got ")
+      (display affected-after-delete)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after delete PASSED")
+      (newline)))
+
+;; Drop table to clean up before next tests
+(dbi-query db-obj "DROP TABLE IF EXISTS dbi_test_table")
+(dbi-query db-obj "CREATE TABLE dbi_test_table (id INTEGER, name VARCHAR(50))")
+
+;; Test 6: affected_rows after SELECT (should be 0)
+(check-status "select for affected_rows"
+  (begin
+    (dbi-query db-obj "SELECT * FROM dbi_test_table")
+    db-obj))
+
+(define affected-after-select (dbi-affected-rows db-obj))
+(if (not (= affected-after-select 0))
+    (begin
+      (display ";;; affected_rows after select FAILED: ")
+      (display "(expected 0 got ")
+      (display affected-after-select)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after select PASSED")
+      (newline)))
+
+;; Test 7: affected_rows updates with each query
+(check-status "first insert for sequence test"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (10, 'Test1')")
+    db-obj))
+
+(define first-affected (dbi-affected-rows db-obj))
+
+(check-status "second insert for sequence test"
+  (begin
+    (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (11, 'Test2'), (12, 'Test3')")
+    db-obj))
+
+(define second-affected (dbi-affected-rows db-obj))
+
+(if (not (and (= first-affected 1) (= second-affected 2)))
+    (begin
+      (display ";;; affected_rows updates after each query FAILED: ")
+      (display "(expected first=1 second=2, got first=")
+      (display first-affected)
+      (display " second=")
+      (display second-affected)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows updates after each query PASSED")
+      (newline)))
+
+;; Cleanup
+(dbi-query db-obj "DROP TABLE IF EXISTS dbi_test_table")
 (dbi-close db-obj)
 
 (display ";;; All PostgreSQL tests completed")

--- a/guile-dbd-sqlite3/src/guile-dbd-sqlite3.c
+++ b/guile-dbd-sqlite3/src/guile-dbd-sqlite3.c
@@ -41,6 +41,7 @@ typedef struct
   sqlite3_stmt *stmt;
   SCM cached_row;
   int has_cached_row;
+  int affected_rows;
 #ifdef PERF_DEBUG
   struct timeval toti;
   struct timeval lati;
@@ -174,6 +175,14 @@ void __sqlite3_close_g_db_handle (gdbi_db_handle_t *dbh)
   }
 }
 
+int __sqlite3_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
+{
+  gdbi_sqlite3_ds_t *db_info = (gdbi_sqlite3_ds_t *)dbh->db_info;
+  if (db_info == NULL)
+    return 0;
+  return db_info->affected_rows;
+}
+
 void __sqlite3_params_query_g_db_handle(
     gdbi_db_handle_t *dbh,
     char *query,
@@ -257,6 +266,7 @@ void __sqlite3_params_query_g_db_handle(
     if (rc == SQLITE_DONE)
     {
         dbh->status = status_cons(0, "query ok");
+        db_info->affected_rows = sqlite3_changes (db_info->sqlite3_obj);
         sqlite3_finalize(stmt);
         db_info->stmt = NULL;
         return;
@@ -317,7 +327,10 @@ void __sqlite3_query_g_db_handle (gdbi_db_handle_t *dbh, char *query_str)
     if (rc != SQLITE_DONE)
       dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
     else
+    {
       dbh->status = status_cons (0, "query ok");
+      db_info->affected_rows = sqlite3_changes (db_info->sqlite3_obj);
+    }
 
     sqlite3_finalize (stmt);
     db_info->stmt = NULL;

--- a/guile-dbd-sqlite3/src/guile-dbd-sqlite3.c
+++ b/guile-dbd-sqlite3/src/guile-dbd-sqlite3.c
@@ -41,7 +41,6 @@ typedef struct
   sqlite3_stmt *stmt;
   SCM cached_row;
   int has_cached_row;
-  int affected_rows;
 #ifdef PERF_DEBUG
   struct timeval toti;
   struct timeval lati;
@@ -175,117 +174,120 @@ void __sqlite3_close_g_db_handle (gdbi_db_handle_t *dbh)
   }
 }
 
-int __sqlite3_affected_rows_g_db_handle (gdbi_db_handle_t *dbh)
+void __sqlite3_params_query_g_db_handle (gdbi_db_handle_t *dbh, char *query,
+                                         int argc, SCM *argv)
 {
-  gdbi_sqlite3_ds_t *db_info = (gdbi_sqlite3_ds_t *)dbh->db_info;
-  if (db_info == NULL)
-    return 0;
-  return db_info->affected_rows;
-}
+  gdbi_sqlite3_ds_t *db_info = dbh->db_info;
+  if (!db_info)
+  {
+    dbh->status = status_cons (1, "invalid dbi connection");
+    return;
+  }
 
-void __sqlite3_params_query_g_db_handle(
-    gdbi_db_handle_t *dbh,
-    char *query,
-    int argc,
-    SCM *argv)
-{
-    gdbi_sqlite3_ds_t *db_info = dbh->db_info;
-    if (!db_info)
+  /* cleanup old stmt */
+  if (db_info->stmt)
+  {
+    sqlite3_finalize (db_info->stmt);
+    db_info->stmt = NULL;
+  }
+
+  db_info->has_cached_row = 0;
+  db_info->cached_row = SCM_UNDEFINED;
+
+  /* prepare statement */
+  sqlite3_stmt *stmt = NULL;
+  int rc = sqlite3_prepare_v2 (db_info->sqlite3_obj, query, -1, &stmt, NULL);
+  if (rc != SQLITE_OK)
+  {
+    dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
+    return;
+  }
+
+  /* bind parameters */
+  if (sqlite3_bind_parameter_count (stmt) != argc)
+  {
+    dbh->status = status_cons (1, "params count mismatch");
+    goto error;
+  }
+
+  for (int i = 0; i < argc; i++)
+  {
+    int idx = i + 1;
+    SCM v = argv[i];
+    if (scm_is_bool (v))
+      rc = sqlite3_bind_int (stmt, idx, scm_is_true (v) ? 1 : 0);
+    else if (scm_is_integer (v))
+      rc = sqlite3_bind_int64 (stmt, idx, scm_to_long_long (v));
+    else if (scm_is_number (v))
+      rc = sqlite3_bind_double (stmt, idx, scm_to_double (v));
+    else if (scm_is_string (v))
     {
-        dbh->status = status_cons(1, "invalid dbi connection");
-        return;
+      char *s = scm_to_locale_string (v);
+      if (!s)
+        goto error;
+      rc = sqlite3_bind_text (stmt, idx, s, -1, SQLITE_TRANSIENT);
+      free (s);
+    }
+    else if (scm_is_null (v))
+      rc = sqlite3_bind_null (stmt, idx);
+    else
+    {
+      dbh->status = status_cons (1, "unsupported parameter type");
+      goto error;
     }
 
-    /* cleanup old stmt */
-    if (db_info->stmt)
-    {
-        sqlite3_finalize(db_info->stmt);
-        db_info->stmt = NULL;
-    }
-
-    /* reset cache */
-    db_info->has_cached_row = 0;
-    db_info->cached_row = SCM_UNDEFINED;
-
-    /* prepare */
-    sqlite3_stmt *stmt = NULL;
-    int rc = sqlite3_prepare_v2(db_info->sqlite3_obj, query, -1, &stmt, NULL);
     if (rc != SQLITE_OK)
     {
-        dbh->status = status_cons(1, sqlite3_errmsg(db_info->sqlite3_obj));
-        return;
+      dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
+      goto error;
     }
+  }
 
-    /* bind params */
-    if (sqlite3_bind_parameter_count(stmt) != argc)
+  /* execute */
+  rc = sqlite3_step (stmt);
+
+  int col_count = sqlite3_column_count (stmt);
+
+  if (col_count == 0)
+  {
+    /* DML */
+    if (rc != SQLITE_DONE)
     {
-        dbh->status = status_cons(1, "params count mismatch");
-        goto error;
+      dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
     }
-
-    for (int i = 0; i < argc; i++)
+    else
     {
-        int idx = i + 1;
-        SCM v = argv[i];
-
-        if (scm_is_bool(v))
-            rc = sqlite3_bind_int(stmt, idx, scm_is_true(v) ? 1 : 0);
-        else if (scm_is_integer(v))
-            rc = sqlite3_bind_int64(stmt, idx, scm_to_long_long(v));
-        else if (scm_is_number(v))
-            rc = sqlite3_bind_double(stmt, idx, scm_to_double(v));
-        else if (scm_is_string(v))
-        {
-            char *s = scm_to_locale_string(v);
-            if (!s) goto error;
-            rc = sqlite3_bind_text(stmt, idx, s, -1, SQLITE_TRANSIENT);
-            free(s);
-        }
-        else if (scm_is_null(v))
-        {
-            rc = sqlite3_bind_null(stmt, idx);
-        }
-        else
-        {
-            dbh->status = status_cons(1, "unsupported parameter type");
-            goto error;
-        }
-
-        if (rc != SQLITE_OK)
-        {
-            dbh->status = status_cons(1, sqlite3_errmsg(db_info->sqlite3_obj));
-            goto error;
-        }
-    }
-
-    /* ================= EXECUTE PROBE ================= */
-
-    rc = sqlite3_step(stmt);
-
-    /* non-select or no row */
-    if (rc == SQLITE_DONE)
-    {
-        dbh->status = status_cons(0, "query ok");
-        db_info->affected_rows = sqlite3_changes (db_info->sqlite3_obj);
-        sqlite3_finalize(stmt);
-        db_info->stmt = NULL;
-        return;
-    }
-
-    /* SELECT with rows */
-    if (rc == SQLITE_ROW)
-    {
-      db_info->cached_row = convert_row (stmt);
-      db_info->has_cached_row = 1;
-
-      db_info->stmt = stmt;
-
       dbh->status = status_cons (0, "query ok");
-      return;
+      dbh->affected_rows = sqlite3_changes (db_info->sqlite3_obj);
     }
+    sqlite3_finalize (stmt);
+    db_info->stmt = NULL;
+    return;
+  }
 
-    /* error */
-    dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
+  /* SELECT query */
+  if (rc == SQLITE_ROW)
+  {
+    db_info->cached_row = convert_row (stmt);
+    db_info->has_cached_row = 1;
+    db_info->stmt = stmt;
+    dbh->status = status_cons (0, "query ok");
+    dbh->affected_rows = 0;
+    return;
+  }
+
+  /* empty SELECT */
+  if (rc == SQLITE_DONE)
+  {
+    dbh->status = status_cons (0, "query ok");
+    dbh->affected_rows = 0;
+    sqlite3_finalize (stmt);
+    db_info->stmt = NULL;
+    return;
+  }
+
+  /* error */
+  dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
 
 error:
   if (stmt)
@@ -309,7 +311,7 @@ void __sqlite3_query_g_db_handle (gdbi_db_handle_t *dbh, char *query_str)
     db_info->stmt = NULL;
   }
 
-  /* prepare the statement */
+  /* prepare statement */
   sqlite3_stmt *stmt = NULL;
   int rc
     = sqlite3_prepare_v2 (db_info->sqlite3_obj, query_str, -1, &stmt, NULL);
@@ -319,39 +321,49 @@ void __sqlite3_query_g_db_handle (gdbi_db_handle_t *dbh, char *query_str)
     return;
   }
 
-  /* Check if the query is a SELECT statement (has columns) */
-  if (sqlite3_column_count (stmt) == 0)
+  int col_count = sqlite3_column_count (stmt);
+
+  if (col_count == 0)
   {
-    /* If no result rows, execute and return immediately */
+    /* DML or no-column statement */
     rc = sqlite3_step (stmt);
     if (rc != SQLITE_DONE)
+    {
       dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
+    }
     else
     {
       dbh->status = status_cons (0, "query ok");
-      db_info->affected_rows = sqlite3_changes (db_info->sqlite3_obj);
+      dbh->affected_rows = sqlite3_changes (db_info->sqlite3_obj);
     }
-
     sqlite3_finalize (stmt);
     db_info->stmt = NULL;
     return;
   }
 
-  /* If SELECT query, cache the first row */
+  /* SELECT query */
   rc = sqlite3_step (stmt);
   if (rc == SQLITE_ROW)
   {
-    // Cache the first row
     db_info->cached_row = convert_row (stmt);
     db_info->has_cached_row = 1;
-
-    // Store the stmt for subsequent use
     db_info->stmt = stmt;
     dbh->status = status_cons (0, "query ok");
+    dbh->affected_rows = 0;
     return;
   }
 
-  /* Handle any other errors */
+  /* empty result set */
+  if (rc == SQLITE_DONE)
+  {
+    dbh->status = status_cons (0, "query ok");
+    dbh->affected_rows = 0;
+    sqlite3_finalize (stmt);
+    db_info->stmt = NULL;
+    return;
+  }
+
+  /* error */
   dbh->status = status_cons (1, sqlite3_errmsg (db_info->sqlite3_obj));
   sqlite3_finalize (stmt);
   db_info->stmt = NULL;

--- a/guile-dbd-sqlite3/test/test-guile-dbd-sqlite3.scm
+++ b/guile-dbd-sqlite3/test/test-guile-dbd-sqlite3.scm
@@ -1,61 +1,202 @@
 #!/usr/bin/env guile
--s
 !#
 
-(use-modules (dbi dbi))
+;;; test-guile-dbi-sqlite.scm - Unit tests for guile-dbi with SQLite
+;;;
+;;; This script is a SQLite3 version of the MySQL-style DBI tests.
 
-(define (check headline result expected) (display ";;; ")
+(use-modules (dbi dbi)
+             (srfi srfi-1))
+
+;; Helper functions
+(define (check headline result expected)
+  (display ";;; ")
   (display headline)
-  (if (equal? result expected) (begin (display " PASSED") (newline))
-    (begin (display " FAILED: ") (display (list "equal?" result expected)) (newline))))
+  (if (equal? result expected)
+      (begin (display " PASSED") (newline))
+      (begin (display " FAILED: ") (display (list "expected" expected "got" result)) (newline))))
 
+(define (check-status headline db-obj)
+  (let ((status (dbi-get_status db-obj)))
+    (display ";;; ")
+    (display headline)
+    (if (zero? (car status))
+        (begin (display " PASSED") (newline) #t)
+        (begin (display " FAILED: ") (display status) (newline) #f))))
+
+;; Temporary SQLite file
 (define db-path
-  (let* ((template (string-copy "/tmp/guile-dbi-test-XXXXXX"))
-         (port (mkstemp! template)))
-    (close-port port)
-    template))
+  (string-append "/tmp/guile-dbi-test-" (symbol->string (gensym)) ".sqlite"))
+
+(display ";;; Using SQLite database: ")
+(display db-path)
+(newline)
+
+;; Open connection
 (define db-obj (dbi-open "sqlite3" db-path))
+(check-status "connect to SQLite" db-obj)
 
-(check "create table"
-  (begin (dbi-query db-obj "create table testtable(id int, name varchar(15))")
-    (dbi-get_status db-obj))
-  '(0 . "query ok"))
+;; Drop table if exists
+(dbi-query db-obj "DROP TABLE IF EXISTS dbi_test_table")
 
-(check "insert"
-  (begin (dbi-query db-obj "insert into testtable ('id', 'name') values('33', 'testname1')")
-    (dbi-query db-obj "insert into testtable ('id', 'name') values('34', 'testname1')")
-    (dbi-query db-obj "insert into testtable ('id', 'name') values('44', 'testname2')")
-    (dbi-get_status db-obj))
-  '(0 . "query ok"))
+;; Create table
+(check-status "create table"
+  (begin
+    (dbi-query db-obj "CREATE TABLE dbi_test_table (id INTEGER, name VARCHAR(50))")
+    db-obj))
 
-(check "select"
-			 (begin (dbi-query db-obj "select * from testtable where name='testname1'")
-							(dbi-get_status db-obj))
-			 '(0 . "query ok"))
+;; Insert rows
+(check-status "insert row 1"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (33, 'testname1')") db-obj))
+(check-status "insert row 2"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (34, 'testname1')") db-obj))
+(check-status "insert row 3"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (44, 'testname2')") db-obj))
 
-(check "get row" (dbi-get_row db-obj) '(("id" . 33) ("name" . "testname1")))
+;; Select rows
+(check-status "select rows where name='testname1'"
+  (begin (dbi-query db-obj "SELECT * FROM dbi_test_table WHERE name='testname1' ORDER BY id") db-obj))
 
-(check "select non-existing row"
-			 (begin (dbi-query db-obj "select * from testtable where name='testname'") (dbi-get_status db-obj))
-			 '(1 . "no more rows available"))
+;; Get rows
+(define row1 (dbi-get_row db-obj))
+(check "get first row" row1 '(("id" . 33) ("name" . "testname1")))
+(define row2 (dbi-get_row db-obj))
+(check "get second row" row2 '(("id" . 34) ("name" . "testname1")))
 
+;; Select non-existing row
+(dbi-query db-obj "SELECT * FROM dbi_test_table WHERE name='nonexistent'")
 (check "get non-existing row" (dbi-get_row db-obj) #f)
 
-(check "count" (begin (dbi-query db-obj "select count(id) from testtable") (dbi-get_status db-obj))
-			 '(0 . "query ok"))
+;; Count query
+(check-status "count query"
+  (begin (dbi-query db-obj "SELECT COUNT(id) as cnt FROM dbi_test_table") db-obj))
+(define count-row (dbi-get_row db-obj))
+(check "get count" (cdr (assoc "cnt" count-row)) 3)
 
-(check "get count" (dbi-get_row db-obj) '(("count(id)" . 3)))
+;;; Affected rows tests
+
+;; Test 1: single insert
+(check-status "insert single row for affected_rows"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (1, 'Alice')") db-obj))
+(define affected-after-single-insert (dbi-affected-rows db-obj))
+(if (not (= affected-after-single-insert 1))
+    (begin
+      (display ";;; affected_rows after single insert FAILED: ")
+      (display "(expected 1 got ")
+      (display affected-after-single-insert)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after single insert PASSED")
+      (newline)))
+
+;; Test 2: multiple insert
+(check-status "insert multiple rows for affected_rows"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (2, 'Bob'), (3, 'Carol'), (4, 'Dave')") db-obj))
+(define affected-after-multi-insert (dbi-affected-rows db-obj))
+(define affected-after-multi-insert (dbi-affected-rows db-obj))
+(if (not (= affected-after-multi-insert 3))
+    (begin
+      (display ";;; affected_rows after multiple inserts FAILED: ")
+      (display "(expected 3 got ")
+      (display affected-after-multi-insert)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after multiple inserts PASSED")
+      (newline)))
+
+;; Test 3: update rows
+(check-status "update rows for affected_rows"
+  (begin (dbi-query db-obj "UPDATE dbi_test_table SET name='Updated' WHERE id IN (2,3)") db-obj))
+(define affected-after-update (dbi-affected-rows db-obj))
+(if (not (= affected-after-update 2))
+    (begin
+      (display ";;; affected_rows after update FAILED: ")
+      (display "(expected 2 got ")
+      (display affected-after-update)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after update PASSED")
+      (newline)))
+
+;; Test 4: update no match
+(check-status "update no matching rows for affected_rows"
+  (begin (dbi-query db-obj "UPDATE dbi_test_table SET name='None' WHERE id=999") db-obj))
+(define affected-after-no-match (dbi-affected-rows db-obj))
+(define affected-after-no-match (dbi-affected-rows db-obj))
+(if (not (= affected-after-no-match 0))
+    (begin
+      (display ";;; affected_rows when update matches nothing FAILED: ")
+      (display "(expected 0 got ")
+      (display affected-after-no-match)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows when update matches nothing PASSED")
+      (newline)))
+
+;; Test 5: delete
+(check-status "delete row for affected_rows"
+  (begin (dbi-query db-obj "DELETE FROM dbi_test_table WHERE id=1") db-obj))
+(define affected-after-delete (dbi-affected-rows db-obj))
+(if (not (= affected-after-delete 1))
+    (begin
+      (display ";;; affected_rows after delete FAILED: ")
+      (display "(expected 1 got ")
+      (display affected-after-delete)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after delete PASSED")
+      (newline)))
+
+;; Drop table to clean up before next tests
+(dbi-query db-obj "DROP TABLE IF EXISTS dbi_test_table")
+(dbi-query db-obj "CREATE TABLE dbi_test_table (id INTEGER, name VARCHAR(50))")
+
+;; Test 6: affected_rows after select (should be 0 in SQLite)
+(check-status "select for affected_rows"
+  (begin (dbi-query db-obj "SELECT * FROM dbi_test_table") db-obj))
+(define affected-after-select (dbi-affected-rows db-obj))
+(if (not (= affected-after-select 0))
+    (begin
+      (display ";;; affected_rows after select FAILED: ")
+      (display "(expected 0 got ")
+      (display affected-after-select)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows after select PASSED")
+      (newline)))
+
+;; Test 7: sequence of inserts
+(check-status "first insert for sequence test"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (10, 'Test1')") db-obj))
+(define first-affected (dbi-affected-rows db-obj))
+
+(check-status "second insert for sequence test"
+  (begin (dbi-query db-obj "INSERT INTO dbi_test_table (id, name) VALUES (11, 'Test2'), (12, 'Test3')") db-obj))
+(define second-affected (dbi-affected-rows db-obj))
+
+(if (not (and (= first-affected 1) (= second-affected 2)))
+    (begin
+      (display ";;; affected_rows updates after each query FAILED: ")
+      (display "(expected first=1 second=2, got first=")
+      (display first-affected)
+      (display " second=")
+      (display second-affected)
+      (display ")")
+      (newline))
+    (begin
+      (display ";;; affected_rows updates after each query PASSED")
+      (newline)))
+
+;; Cleanup
+(dbi-query db-obj "DROP TABLE dbi_test_table")
 (dbi-close db-obj)
-
-(check "open/close not leaking file descriptors, not segfaulting"
-			 (do ((i 0 (1+ i)) (result #f)) ((> i 2048) result)
-				 (let ((db-obj (dbi-open "sqlite3" db-path))) (dbi-query db-obj "SELECT 42")
-							(dbi-query db-obj "BEGIN IMMEDIATE TRANSACTION")
-							(dbi-query db-obj "CREATE TABLE IF NOT EXISTS testtable (id INTEGER)")
-							(dbi-query db-obj "INSERT INTO testtable SET (id) VALUES (23)")
-							(dbi-query db-obj "SELECT * FROM testtable") (dbi-query db-obj "SELECT * FROM testtable")
-							(dbi-query db-obj "SELECT * FROM non-existent") (dbi-query db-obj "COMMIT TRANSACTION")
-							(when (= i 1024) (set! result (dbi-get_status db-obj))) (dbi-close db-obj)))
-			 '(0 . "query ok"))
-
 (delete-file db-path)
+
+(display ";;; All SQLite tests completed")
+(newline)

--- a/guile-dbi/include/guile-dbi/guile-dbi.h
+++ b/guile-dbi/include/guile-dbi/guile-dbi.h
@@ -1,5 +1,5 @@
 /* guile-dbi.h - Main include file
- * Copyright (C) 2004, 2005 Free Software Foundation, Inc.
+ * Copyright (C) 2004, 2005, 2026 Free Software Foundation, Inc.
  * Written by Maurizio Boriani <baux@member.fsf.org>
  *
  * This file is part of the guile-dbi.
@@ -53,6 +53,6 @@ void init_dbi(void);
 
 /* dbd dynamic wrapper stuff */
 void __gdbi_dbd_wrap(gdbi_db_handle_t* dbh, const char* function_name,
-		     void** function_pointer);
+                     void** function_pointer);
 /* end dbd dynamic wrapper stuff */
 #endif

--- a/guile-dbi/include/guile-dbi/guile-dbi.h
+++ b/guile-dbi/include/guile-dbi/guile-dbi.h
@@ -36,6 +36,7 @@ typedef struct
   lt_dlhandle handle;
   void* db_info;
   int in_free;  /* boolean, used to avoid alloc during garbage collection */
+  int affected_rows; /* number of rows affected by last query */
   const char * bcknd_str;
   size_t bcknd_strlen;
 } gdbi_db_handle_t;

--- a/guile-dbi/include/guile-dbi/guile-dbi.h
+++ b/guile-dbi/include/guile-dbi/guile-dbi.h
@@ -36,9 +36,9 @@ typedef struct
   lt_dlhandle handle;
   void* db_info;
   int in_free;  /* boolean, used to avoid alloc during garbage collection */
-  int affected_rows; /* number of rows affected by last query */
   const char * bcknd_str;
   size_t bcknd_strlen;
+  long long affected_rows; /* number of rows affected by last query */
 } gdbi_db_handle_t;
 /* end guile smob struct */
 

--- a/guile-dbi/src/dbi/dbi.scm
+++ b/guile-dbi/src/dbi/dbi.scm
@@ -30,4 +30,5 @@
         dbi-params-query
         dbi-query
         dbi-get_row
-        dbi-get_status)
+        dbi-get_status
+        dbi-affected-rows)

--- a/guile-dbi/src/guile-dbi.c
+++ b/guile-dbi/src/guile-dbi.c
@@ -51,6 +51,7 @@ SCM_DEFINE (make_g_db_handle, "dbi-open", 2, 0, 0, (SCM bcknd, SCM conn_string),
   g_db_handle->handle = NULL;
   g_db_handle->closed = SCM_BOOL_T;
   g_db_handle->in_free = 0;
+  g_db_handle->affected_rows = 0; /* kept for backward compatibility, not used */
   g_db_handle->db_info = NULL;
   g_db_handle->bcknd_str = scm_to_locale_string (bcknd);
   g_db_handle->bcknd_strlen = strlen (g_db_handle->bcknd_str);
@@ -285,6 +286,25 @@ SCM_DEFINE (getrow_g_db_handle, "dbi-get_row", 1, 0, 0, (SCM db_handle),
 
   scm_remember_upto_here_1 (db_handle);
   return (retrow);
+}
+#undef FUNC_NAME
+
+SCM_DEFINE (affected_rows_g_db_handle, "dbi-affected-rows", 1, 0, 0,
+            (SCM db_handle),
+            "Return number of rows affected by the last query.")
+#define FUNC_NAME s_affected_rows_g_db_handle
+{
+  gdbi_db_handle_t *g_db_handle = NULL;
+
+  SCM_ASSERT (DBI_SMOB_P (db_handle), db_handle, SCM_ARG1, FUNC_NAME);
+
+  g_db_handle = (gdbi_db_handle_t *)SCM_SMOB_DATA (db_handle);
+
+  if (g_db_handle == NULL)
+    return SCM_BOOL_F;
+
+  scm_remember_upto_here_1 (db_handle);
+  return scm_from_int (g_db_handle->affected_rows);
 }
 #undef FUNC_NAME
 

--- a/guile-dbi/src/guile-dbi.c
+++ b/guile-dbi/src/guile-dbi.c
@@ -28,7 +28,7 @@
 
 static scm_t_bits g_db_handle_tag;
 
-#define DBI_SMOB_P(obj) \
+#define DBI_SMOB_P(obj)                                       \
   ((SCM_NIMP (obj)) && (SCM_TYP16 (obj) == g_db_handle_tag))
 
 SCM_DEFINE (make_g_db_handle, "dbi-open", 2, 0, 0, (SCM bcknd, SCM conn_string),
@@ -51,46 +51,46 @@ SCM_DEFINE (make_g_db_handle, "dbi-open", 2, 0, 0, (SCM bcknd, SCM conn_string),
   g_db_handle->handle = NULL;
   g_db_handle->closed = SCM_BOOL_T;
   g_db_handle->in_free = 0;
-  g_db_handle->affected_rows = 0; /* kept for backward compatibility, not used */
+  g_db_handle->affected_rows = 0;
   g_db_handle->db_info = NULL;
   g_db_handle->bcknd_str = scm_to_locale_string (bcknd);
   g_db_handle->bcknd_strlen = strlen (g_db_handle->bcknd_str);
 
   sodbd_len = sizeof (char)
-              * (strlen ("libguile-dbd-") + g_db_handle->bcknd_strlen + 1);
+    * (strlen ("libguile-dbd-") + g_db_handle->bcknd_strlen + 1);
   sodbd = (char *)malloc (sodbd_len);
   if (sodbd == NULL)
-  {
-    g_db_handle->status = scm_cons (scm_from_int (errno),
-                                    scm_from_locale_string (strerror (errno)));
-    SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
-  }
+    {
+      g_db_handle->status = scm_cons (scm_from_int (errno),
+                                      scm_from_locale_string (strerror (errno)));
+      SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
+    }
 
   snprintf (sodbd, sodbd_len, "libguile-dbd-%s", g_db_handle->bcknd_str);
 
   g_db_handle->handle = lt_dlopenext (sodbd);
   if (g_db_handle->handle == NULL)
-  {
-    free (sodbd);
-    g_db_handle->status
-      = scm_cons (scm_from_int (1), scm_from_locale_string (lt_dlerror ()));
-    SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
-  }
+    {
+      free (sodbd);
+      g_db_handle->status
+        = scm_cons (scm_from_int (1), scm_from_locale_string (lt_dlerror ()));
+      SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
+    }
 
   __gdbi_dbd_wrap (g_db_handle, __FUNCTION__, (void **)&connect);
   if (scm_equal_p (SCM_CAR (g_db_handle->status), scm_from_int (0))
       == SCM_BOOL_F)
-  {
-    free (sodbd);
-    SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
-  }
+    {
+      free (sodbd);
+      SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
+    }
 
   (*connect) (g_db_handle);
 
   if (sodbd != NULL)
-  {
-    free (sodbd);
-  }
+    {
+      free (sodbd);
+    }
 
   SCM_RETURN_NEWSMOB (g_db_handle_tag, g_db_handle);
 }
@@ -118,13 +118,13 @@ static int print_db_handle (SCM g_db_handle_smob, SCM port,
 
   scm_puts ("#<guile-dbi ", port);
   if (scm_equal_p (g_db_handle->closed, SCM_BOOL_T) == SCM_BOOL_T)
-  {
-    scm_puts ("close ", port);
-  }
+    {
+      scm_puts ("close ", port);
+    }
   else
-  {
-    scm_puts ("open ", port);
-  }
+    {
+      scm_puts ("open ", port);
+    }
   scm_display (g_db_handle->bcknd, port);
   scm_puts (" ", port);
   scm_display (g_db_handle->constr, port);
@@ -148,24 +148,24 @@ SCM_DEFINE (close_g_db_handle, "dbi-close", 1, 0, 0, (SCM db_handle),
   g_db_handle = (gdbi_db_handle_t *)SCM_SMOB_DATA (db_handle);
 
   if (g_db_handle->closed == SCM_BOOL_T)
-  {
-    return SCM_UNSPECIFIED;
-  }
+    {
+      return SCM_UNSPECIFIED;
+    }
 
   __gdbi_dbd_wrap (g_db_handle, __FUNCTION__, (void **)&dbd_close);
   if (scm_equal_p (SCM_CAR (g_db_handle->status), scm_from_int (0))
       == SCM_BOOL_F)
-  {
-    scm_remember_upto_here_1 (db_handle);
-    return SCM_UNSPECIFIED;
-  }
+    {
+      scm_remember_upto_here_1 (db_handle);
+      return SCM_UNSPECIFIED;
+    }
 
   (*dbd_close) (g_db_handle);
   if (g_db_handle->handle)
-  {
-    lt_dlclose (g_db_handle->handle);
-    g_db_handle->handle = NULL;
-  }
+    {
+      lt_dlclose (g_db_handle->handle);
+      g_db_handle->handle = NULL;
+    }
 
   scm_remember_upto_here_1 (db_handle);
   return SCM_UNSPECIFIED;
@@ -184,10 +184,10 @@ static size_t free_db_handle (SCM g_db_handle_smob)
   close_g_db_handle (g_db_handle_smob);
 
   if (g_db_handle != NULL)
-  {
-    free ((void *)g_db_handle->bcknd_str);
-    scm_gc_free (g_db_handle, sizeof (gdbi_db_handle_t), "g_db_handle");
-  }
+    {
+      free ((void *)g_db_handle->bcknd_str);
+      scm_gc_free (g_db_handle, sizeof (gdbi_db_handle_t), "g_db_handle");
+    }
 
   SCM_SETCDR (g_db_handle_smob, SCM_EOL);
   return 0;
@@ -211,9 +211,9 @@ SCM_DEFINE (query_g_db_handle, "dbi-query", 2, 0, 0, (SCM db_handle, SCM query),
   __gdbi_dbd_wrap (g_db_handle, __FUNCTION__, (void **)&dbi_query);
   if (scm_equal_p (SCM_CAR (g_db_handle->status), scm_from_int (0))
       == SCM_BOOL_T)
-  {
-    (*dbi_query) (g_db_handle, query_str);
-  }
+    {
+      (*dbi_query) (g_db_handle, query_str);
+    }
 
   free (query_str);
   scm_remember_upto_here_1 (db_handle);
@@ -242,20 +242,20 @@ SCM_DEFINE (params_query_g_db_handle, "dbi-params-query", 3, 0, 0,
 
   if (scm_equal_p (SCM_CAR (g_db_handle->status), scm_from_int (0))
       == SCM_BOOL_T)
-  {
-    int argc = scm_to_int (scm_length (params));
-    SCM *argv = (SCM *)calloc (sizeof (SCM), argc);
-    SCM lst = params;
-
-    for (int i = 0; i < argc; i++)
     {
-      argv[i] = SCM_CAR (lst);
-      lst = SCM_CDR (lst);
-    }
+      int argc = scm_to_int (scm_length (params));
+      SCM *argv = (SCM *)calloc (sizeof (SCM), argc);
+      SCM lst = params;
 
-    (*dbi_params_query) (g_db_handle, query_str, argc, argv);
-    free (argv);
-  }
+      for (int i = 0; i < argc; i++)
+        {
+          argv[i] = SCM_CAR (lst);
+          lst = SCM_CDR (lst);
+        }
+
+      (*dbi_params_query) (g_db_handle, query_str, argc, argv);
+      free (argv);
+    }
 
   free (query_str);
   scm_remember_upto_here_1 (db_handle);
@@ -277,10 +277,10 @@ SCM_DEFINE (getrow_g_db_handle, "dbi-get_row", 1, 0, 0, (SCM db_handle),
   __gdbi_dbd_wrap (g_db_handle, __FUNCTION__, (void **)&dbi_getrow);
   if (scm_equal_p (SCM_CAR (g_db_handle->status), scm_from_int (0))
       == SCM_BOOL_F)
-  {
-    scm_remember_upto_here_1 (db_handle);
-    return (retrow);
-  }
+    {
+      scm_remember_upto_here_1 (db_handle);
+      return (retrow);
+    }
 
   retrow = (*dbi_getrow) (g_db_handle);
 
@@ -319,10 +319,10 @@ SCM_DEFINE (getstat_g_db_handle, "dbi-get_status", 1, 0, 0, (SCM db_handle),
   g_db_handle = (gdbi_db_handle_t *)SCM_SMOB_DATA (db_handle);
 
   if (g_db_handle != NULL)
-  {
-    scm_remember_upto_here_1 (db_handle);
-    return (g_db_handle->status);
-  }
+    {
+      scm_remember_upto_here_1 (db_handle);
+      return (g_db_handle->status);
+    }
 
   return (SCM_BOOL_F);
 }
@@ -333,8 +333,8 @@ void init_db_handle_type (void)
 {
   g_db_handle_tag
     = scm_make_smob_type ("g_db_handle", sizeof (gdbi_db_handle_t));
-/* guile-2.0 and newer should not do this.
-   See http://lists.gnu.org/archive/html/guile-user/2011-11/msg00074.html */
+  /* guile-2.0 and newer should not do this.
+     See http://lists.gnu.org/archive/html/guile-user/2011-11/msg00074.html */
 #if 0
   scm_set_smob_mark (g_db_handle_tag, mark_db_handle);
 #endif
@@ -368,26 +368,26 @@ void __gdbi_dbd_wrap (gdbi_db_handle_t *dbh, const char *function_name,
   func_len = sizeof (char) * (strlen (function_name) + dbh->bcknd_strlen + 10);
   func = malloc (func_len);
   if (NULL == func)
-  {
-    if (dbh->in_free)
-      return; /* do not SCM anything while in GC */
-    dbh->status = scm_cons (scm_from_int (errno),
-                            scm_from_locale_string (strerror (errno)));
-    return;
-  }
+    {
+      if (dbh->in_free)
+        return; /* do not SCM anything while in GC */
+      dbh->status = scm_cons (scm_from_int (errno),
+                              scm_from_locale_string (strerror (errno)));
+      return;
+    }
 
   /* I assume this is correct for all OS'es */
   snprintf (func, func_len, "__%s_%s", dbh->bcknd_str, function_name);
   lt_dlerror (); /* Clear any existing error -- Solaris needs this */
   *function_pointer = lt_dlsym (dbh->handle, func);
   if ((ret = lt_dlerror ()) != NULL)
-  {
-    free (func);
-    if (dbh->in_free)
-      return; /* do not SCM anything while in GC */
-    dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string (ret));
-    return;
-  }
+    {
+      free (func);
+      if (dbh->in_free)
+        return; /* do not SCM anything while in GC */
+      dbh->status = scm_cons (scm_from_int (1), scm_from_locale_string (ret));
+      return;
+    }
 
   free (func);
 

--- a/guile-dbi/src/test/guile-dbd-test.c
+++ b/guile-dbi/src/test/guile-dbd-test.c
@@ -36,6 +36,7 @@ void __test_make_g_db_handle(gdbi_db_handle_t* dbh);
 void __test_close_g_db_handle(gdbi_db_handle_t* dbh);
 void __test_query_g_db_handle(gdbi_db_handle_t* dbh, char* query);
 SCM __test_getrow_g_db_handle(gdbi_db_handle_t* dbh);
+int __test_affected_rows_g_db_handle(gdbi_db_handle_t* dbh);
 
 
 typedef struct gdbi_test_ds
@@ -89,6 +90,7 @@ __test_query_g_db_handle(gdbi_db_handle_t* dbh, char* query)
     }
   dbh->status = (SCM) scm_cons(scm_from_int(0),
 			       scm_from_locale_string("test query ok"));
+  dbh->affected_rows = 0;
   return;
 }
 
@@ -106,4 +108,10 @@ __test_getrow_g_db_handle(gdbi_db_handle_t* dbh)
   dbh->status = (SCM) scm_cons(scm_from_int(0),
 			       scm_from_locale_string("row retrieved"));
   return (SCM_BOOL_F);
+}
+
+int
+__test_affected_rows_g_db_handle(gdbi_db_handle_t* dbh)
+{
+  return dbh->affected_rows;
 }

--- a/guile-dbi/src/test/guile-dbd-test.c
+++ b/guile-dbi/src/test/guile-dbd-test.c
@@ -1,19 +1,19 @@
 /* guile-dbd-test.c - Dummy driver used for dbi testing
- * Copyright (C) 2004, 2005, 2006 Free Software Foundation, Inc.
+ * Copyright (C) 2004, 2005, 2006, 2026 Free Software Foundation, Inc.
  * Written by Maurizio Boriani <baux@member.fsf.org>
  *
  * This file is part of the guile-dbi.
- * 
+ *
  * The guile-dbi is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * The guile-dbi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
@@ -29,7 +29,7 @@
 
 
 
-/* functions prototypes and structures 
+/* functions prototypes and structures
    the word 'test' in function name is exactly the db type use to call
    this driver */
 void __test_make_g_db_handle(gdbi_db_handle_t* dbh);
@@ -52,14 +52,14 @@ __test_make_g_db_handle(gdbi_db_handle_t* dbh)
   if(scm_is_true(scm_string_p(dbh->constr)) == 0)
     {
       dbh->status = (SCM) scm_cons(scm_from_int(1),
-				   scm_from_locale_string("missing connection string"));
+                                   scm_from_locale_string("missing connection string"));
       dbh->closed = SCM_BOOL_T;
       return;
     }
   else
     {
       dbh->status = (SCM) scm_cons(scm_from_int(0),
-				   scm_from_locale_string("test connect ok"));
+                                   scm_from_locale_string("test connect ok"));
       dbh->closed = SCM_BOOL_F;
     }
   return;
@@ -67,12 +67,12 @@ __test_make_g_db_handle(gdbi_db_handle_t* dbh)
 
 
 
-void 
+void
 __test_close_g_db_handle(gdbi_db_handle_t* dbh)
 {
   dbh->db_info = NULL;
   dbh->status = (SCM) scm_cons(scm_from_int(0),
-			       scm_from_locale_string("test close ok"));
+                               scm_from_locale_string("test close ok"));
   dbh->closed = SCM_BOOL_T;
   return;
 }
@@ -85,11 +85,11 @@ __test_query_g_db_handle(gdbi_db_handle_t* dbh, char* query)
   if (dbh->closed == SCM_BOOL_T)
     {
       dbh->status = (SCM) scm_cons(scm_from_int(1),
-				   scm_from_locale_string("connection closed"));
+                                   scm_from_locale_string("connection closed"));
       return;
     }
   dbh->status = (SCM) scm_cons(scm_from_int(0),
-			       scm_from_locale_string("test query ok"));
+                               scm_from_locale_string("test query ok"));
   dbh->affected_rows = 0;
   return;
 }
@@ -102,11 +102,11 @@ __test_getrow_g_db_handle(gdbi_db_handle_t* dbh)
   if (dbh->closed == SCM_BOOL_T)
     {
       dbh->status = (SCM) scm_cons(scm_from_int(1),
-				   scm_from_locale_string("connection closed"));
+                                   scm_from_locale_string("connection closed"));
       return SCM_BOOL_F;
     }
   dbh->status = (SCM) scm_cons(scm_from_int(0),
-			       scm_from_locale_string("row retrieved"));
+                               scm_from_locale_string("row retrieved"));
   return (SCM_BOOL_F);
 }
 

--- a/guile-dbi/src/test/test-guile-dbi.scm
+++ b/guile-dbi/src/test/test-guile-dbi.scm
@@ -81,6 +81,22 @@
 ;; Capture results before test-end clears the runner
 (define test-result (test-runner-fail-count (test-runner-current)))
 
+(test-assert "dbi-affected-rows returns integer after open"
+  (integer? (dbi-affected-rows dbh)))
+
+(test-assert "dbi-affected-rows returns 0 after open"
+  (zero? (dbi-affected-rows dbh)))
+
+(test-assert "dbi-affected-rows returns integer after query"
+  (begin
+    (dbi-query dbh "select * from test;")
+    (integer? (dbi-affected-rows dbh))))
+
+(test-assert "dbi-affected-rows returns 0 after query"
+  (begin
+    (dbi-query dbh "select * from test;")
+    (zero? (dbi-affected-rows dbh))))
+
 (test-end "guile-dbi")
 
 ;; Exit with proper status for make check


### PR DESCRIPTION
`affected rows` is the de facto standard way to determine whether an atomic transactional update actually modified any rows. This is widely used by modern database frameworks and ORMs for concurrency-safe state transitions.

The tests are passed for me.