### PR TITLE
Add pgvector read support, fix NaN/Infinity float bug

### DIFF
--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -44,6 +44,14 @@ typedef struct
   int lget;
   int retn;
   int is_params; /* 1 = came from PQexecParams, 0 = came from PQexec */
+  /* pgvector's `vector' type has no compile-time-stable OID like the
+     built-ins in pg_oid.h -- CREATE EXTENSION vector assigns it
+     dynamically, and it differs per database/installation. Looked up
+     once per connection and cached here. 0 (InvalidOid) means "not
+     installed on this database" -- not an error, just means this
+     connection will never see a vector column, so the cached value
+     never matches any real column type. */
+  Oid vector_oid;
 } gdbi_pgsql_ds_t;
 
 static void dbi_set_error (gdbi_db_handle_t *dbh, const char *msg)
@@ -158,6 +166,23 @@ void __postgresql_make_g_db_handle (gdbi_db_handle_t *dbh)
     }
     else
     {
+      /* pgvector's `vector' type has no stable compile-time OID (see
+         struct comment) -- look it up once now, while we know the
+         connection is good. A miss (query fails, or 0 rows because the
+         extension isn't installed on this database) is not a
+         connection error: it just means vector_oid stays 0 and no
+         column will ever match it. */
+      PGresult *voidres = PQexec (pgsqlP->pgsql,
+                                  "SELECT oid FROM pg_type WHERE typname = 'vector'");
+      pgsqlP->vector_oid = 0;
+      if (voidres && PQresultStatus (voidres) == PGRES_TUPLES_OK
+          && PQntuples (voidres) == 1)
+      {
+        pgsqlP->vector_oid = (Oid) atoi (PQgetvalue (voidres, 0, 0));
+      }
+      if (voidres)
+        PQclear (voidres);
+
       /* todo: error msg to be translated */
       dbh->status
         = scm_cons (scm_from_int (0), scm_from_utf8_string ("db connected"));
@@ -426,13 +451,23 @@ static SCM getrow_for_params (gdbi_db_handle_t *dbh)
       break;
 
     default:
-    {
-      char msg[101];
-      snprintf (msg, 100, "unknown field type %d for %s", type, fname);
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
-      pgsqlP->lget++;
-      return SCM_BOOL_F;
-    }
+      /* pgvector: OID isn't known at compile time, so it can't be its
+         own `case' label -- checked here at runtime instead, against
+         the value looked up once at connection time. Text output looks
+         like "[0.1,0.2,0.3]"; decoding it into actual numbers, if ever
+         needed, is Scheme-side work, not this driver's job. */
+      if (pgsqlP->vector_oid != 0 && type == pgsqlP->vector_oid)
+      {
+        value = scm_from_locale_stringn (vstr, vlen);
+        break;
+      }
+      {
+        char msg[101];
+        snprintf (msg, 100, "unknown field type %d for %s", type, fname);
+        dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
+        pgsqlP->lget++;
+        return SCM_BOOL_F;
+      }
     }
 
     retrow = scm_append (scm_list_2 (
@@ -554,9 +589,15 @@ SCM __postgresql_getrow_g_db_handle (gdbi_db_handle_t *dbh)
 
     case FLOAT4OID:
     case FLOAT8OID:
-      value = scm_c_locale_stringn_to_number (vstr, strlen (vstr), 10);
-      if (scm_is_false (value))
-        value = scm_from_double (0.0);
+      /* atof (via strtod) correctly parses postgres's literal "NaN" /
+         "Infinity" / "-Infinity" text output per C99 (confirmed:
+         atof("NaN") -> nan, atof("Infinity") -> inf). Guile's own
+         number reader does NOT recognize these bare forms (confirmed:
+         (string->number "NaN") => #f) -- the previous code's
+         scm_is_false-then-0.0 fallback silently turned real NaN/
+         Infinity values into 0.0. This now matches the params-path's
+         float handling below, which never had this bug. */
+      value = scm_from_double (atof (vstr));
       break;
 
     case MONEYOID:
@@ -621,13 +662,26 @@ SCM __postgresql_getrow_g_db_handle (gdbi_db_handle_t *dbh)
       break;
 
     default:
-    {
-      char msg[101];
-      snprintf (msg, 100, "unknown field type %d for %s", type, fname);
-      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
-      pgsqlP->lget++;
-      return SCM_BOOL_F;
-    }
+      /* pgvector: OID isn't known at compile time, so it can't be its
+         own `case' label -- checked here at runtime instead, against
+         the value looked up once at connection time. Text output looks
+         like "[0.1,0.2,0.3]"; decoding it into actual numbers, if ever
+         needed, is Scheme-side work, not this driver's job. This path
+         has no shared vlen variable (unlike getrow_for_params), so
+         length is computed locally, same as BYTEAOID's case above. */
+      if (pgsqlP->vector_oid != 0 && type == pgsqlP->vector_oid)
+      {
+        size_t vveclen = PQgetlength (pgsqlP->res, pgsqlP->lget, f);
+        value = scm_from_locale_stringn (vstr, vveclen);
+        break;
+      }
+      {
+        char msg[101];
+        snprintf (msg, 100, "unknown field type %d for %s", type, fname);
+        dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
+        pgsqlP->lget++;
+        return SCM_BOOL_F;
+      }
     }
 
     retrow = scm_append (scm_list_2 (

--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -461,13 +461,12 @@ static SCM getrow_for_params (gdbi_db_handle_t *dbh)
         value = scm_from_locale_stringn (vstr, vlen);
         break;
       }
-      {
-        char msg[101];
-        snprintf (msg, 100, "unknown field type %d for %s", type, fname);
-        dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
-        pgsqlP->lget++;
-        return SCM_BOOL_F;
-      }
+
+      char msg[101];
+      snprintf (msg, 100, "unknown field type %d for %s", type, fname);
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
+      pgsqlP->lget++;
+      return SCM_BOOL_F;
     }
 
     retrow = scm_append (scm_list_2 (
@@ -675,13 +674,12 @@ SCM __postgresql_getrow_g_db_handle (gdbi_db_handle_t *dbh)
         value = scm_from_locale_stringn (vstr, vveclen);
         break;
       }
-      {
-        char msg[101];
-        snprintf (msg, 100, "unknown field type %d for %s", type, fname);
-        dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
-        pgsqlP->lget++;
-        return SCM_BOOL_F;
-      }
+
+      char msg[101];
+      snprintf (msg, 100, "unknown field type %d for %s", type, fname);
+      dbh->status = scm_cons (scm_from_int (1), scm_from_utf8_string (msg));
+      pgsqlP->lget++;
+      return SCM_BOOL_F;
     }
 
     retrow = scm_append (scm_list_2 (

--- a/guile-dbd-postgresql/test/test-postgresql-params.scm
+++ b/guile-dbd-postgresql/test/test-postgresql-params.scm
@@ -40,7 +40,8 @@
 
 (use-modules (dbi dbi)
              (ice-9 format)
-             (ice-9 match))
+             (ice-9 match)
+             (srfi srfi-1))
 
 ;;; ── connection string ────────────────────────────────────────────────────────
 ;;; Test prepare:
@@ -114,7 +115,16 @@
 
 ;; Create a scratch table covering all OID branches we care about.
 (exec! db "DROP TABLE IF EXISTS _dbi_param_test")
-(exec! db "
+
+;; pgvector is optional -- CREATE EXTENSION IF NOT EXISTS is itself the
+;; probe: if it fails (no pgvector package installed on this server at
+;; all, as opposed to just "not enabled in this database"), skip the
+;; vector column and its test rather than failing the whole suite.
+(dbi-query db "CREATE EXTENSION IF NOT EXISTS vector")
+(define has-vector? (= 0 (car (dbi-get_status db))))
+
+(exec! db
+  (string-append "
 CREATE TABLE _dbi_param_test (
   id          SERIAL PRIMARY KEY,
   col_bool    BOOLEAN,
@@ -132,8 +142,9 @@ CREATE TABLE _dbi_param_test (
   col_int8arr BIGINT[],
   col_json    JSON,
   col_jsonb   JSONB,
-  col_uuid    UUID
-)")
+  col_uuid    UUID"
+    (if has-vector? ",\n  col_vector  VECTOR(3)" "")
+    "\n)"))
 
 ;; Row 1: fully populated
 (exec! db "
@@ -153,6 +164,11 @@ VALUES
    '{\"key\":\"val\"}',
    '{\"k\":1}',
    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')")
+
+;; Row 1's vector value, set separately so the main INSERT above stays
+;; identical whether or not pgvector is installed.
+(when has-vector?
+  (exec! db "UPDATE _dbi_param_test SET col_vector = '[0.5,1.5,2.5]' WHERE col_text = 'hello params'"))
 
 ;; Row 2: NULLs for every nullable column
 (exec! db "
@@ -202,6 +218,13 @@ VALUES
   (check-true!        "json is string"           (string? (col row "col_json")))
   (check-true!        "jsonb is string"          (string? (col row "col_jsonb")))
   (check-true!        "uuid is string"           (string? (col row "col_uuid")))
+  ;; pgvector -> string, same as json/jsonb/uuid: this driver hands back
+  ;; the type's text representation, not parsed Scheme numbers -- decoding
+  ;; "[0.5,1.5,2.5]" into a list of floats, if ever needed, is
+  ;; application-side work.
+  (when has-vector?
+    (check-true!      "vector is string"          (string? (col row "col_vector")))
+    (check!           "vector text form"          (col row "col_vector") "[0.5,1.5,2.5]"))
   ;; Drain remaining rows
   (fetch-all db))
 
@@ -221,6 +244,8 @@ VALUES
   (check-unspecified! "null float4"             (col row "col_float4"))
   (check-unspecified! "null float8"             (col row "col_float8"))
   (check-unspecified! "null numeric"            (col row "col_numeric"))
+  (when has-vector?
+    (check-unspecified! "null vector"           (col row "col_vector")))
   (check-unspecified! "null text"               (col row "col_text"))
   (check-unspecified! "null int4arr"            (col row "col_int4arr"))
   (fetch-all db))
@@ -289,6 +314,36 @@ VALUES
     (let ((row (fetch-one db)))
       (check! "recovery after error" (col row "msg") "recovered")
       (fetch-all db))))
+
+;;; ── teardown ─────────────────────────────────────────────────────────────────
+;;; ── Test 9: float edge cases -- NaN / Infinity (regression) ─────────────────
+;;; Guards the bug where the PQexec path silently turned real NaN/Infinity
+;;; float4/float8 values into 0.0 (Guile's number reader doesn't recognize
+;;; postgres's bare "NaN"/"Infinity" text form and the old fallback assumed
+;;; parse failure meant "just use zero"). This exercises the PQexec path
+;;; specifically (exec!, not params-exec!), since that's the path that had
+;;; the bug -- the params path already used plain atof and was never broken.
+(format #t "\n-- Test 9: float NaN/Infinity (PQexec path regression) --\n")
+
+(exec! db "DROP TABLE IF EXISTS _dbi_float_edge_test")
+(exec! db "CREATE TABLE _dbi_float_edge_test (label TEXT, val DOUBLE PRECISION)")
+(exec! db "INSERT INTO _dbi_float_edge_test VALUES
+  ('nan', 'NaN'::double precision),
+  ('pinf', 'Infinity'::double precision),
+  ('ninf', '-Infinity'::double precision)")
+
+(exec! db "SELECT label, val FROM _dbi_float_edge_test ORDER BY label")
+(let ((rows (fetch-all db)))
+  (define (val-for label)
+    (and=> (find (lambda (r) (equal? (col r "label") label)) rows)
+           (lambda (r) (col r "val"))))
+  (check-true! "nan is real and not zero"
+               (let ((v (val-for "nan"))) (and (real? v) (not (= v 0.0)))))
+  (check-true! "+inf is real and not zero"
+               (let ((v (val-for "pinf"))) (and (real? v) (not (= v 0.0)))))
+  (check-true! "-inf is real and not zero"
+               (let ((v (val-for "ninf"))) (and (real? v) (not (= v 0.0))))))
+(exec! db "DROP TABLE IF EXISTS _dbi_float_edge_test")
 
 ;;; ── teardown ─────────────────────────────────────────────────────────────────
 (exec! db "DROP TABLE IF EXISTS _dbi_param_test")


### PR DESCRIPTION
pgvector's `vector` type has no compile-time-stable OID (CREATE EXTENSION assigns it dynamically, per-database) unlike the built-ins in pg_oid.h, so it can't be its own switch-case label the way BOOLOID/TEXTOID/etc. are. Both result-decoding paths (getrow_for_params and the plain PQexec path) hit the `default:` branch for any OID they don't recognize and fail the whole row -- this made any SELECT returning a vector column unusable.

- Look up `vector`'s OID once per connection (query pg_type, cache on the connection struct); 0 means "not installed on this database", not an error.
- Both default-case branches now check the cached OID before falling through to the existing "unknown field type" error, decoding a match as text (e.g. "[0.1,0.2,0.3]") -- same treatment as uuid/json/jsonb. All other unrecognized OIDs still error exactly as before.
- Write side needs no change: parameter binding only accepts string/ number/bool/null (anything else already errors as "unsupported parameter"), so a vector value was never bindable as a param in the first place regardless of pgvector. Callers write vector literals by embedding text directly in the query, not via bound parameters.

Also fixes a real, unrelated bug found during this pass: the PQexec path's FLOAT4OID/FLOAT8OID case parsed values through Guile's own number reader, which does not recognize postgres's literal "NaN" / "Infinity" / "-Infinity" text output (confirmed: (string->number "NaN") => #f) -- the existing fallback treated that parse failure as "just use 0.0", silently corrupting any real NaN/Infinity float value into zero. Switched to atof (via strtod), which correctly parses these per C99 (confirmed against libc: atof("NaN") -> nan, atof("Infinity") -> inf). This now matches the params path's float handling, which used plain atof already and never had the bug.

Tests (test-postgresql-params.scm):
- CREATE EXTENSION IF NOT EXISTS vector doubles as an availability probe; the vector column and its assertions are skipped entirely if pgvector isn't installed, rest of the suite unaffected.
- Type-fidelity and NULL-handling checks for the new vector column, same pattern as the existing json/jsonb/uuid checks.
- New Test 9: NaN/Infinity round-trip through the PQexec path specifically (exec!, not params-exec!) -- regression coverage for the float fix above; the params path never had this bug so isn't the interesting path to test it against.